### PR TITLE
Add links and about managed apps to Loki readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ repository to track and adjust or charts maintained by Grafana Labs.
 
 Once your Kubernetes clusters are up and running, you can use dozens of apps to take control of every part of your cluster. For example, apps to configure DNS servers (External DNS), to generate and renew certificates (Cert Manager), to monitor (Prometheus), to log (EFK or Loki), and to trace (Jaeger) your workloads, to keep your clusters secure, to autoscale resources… and many more.
 
-To help with these, we provide managed apps. Between DIY-ing open source tools and contracting with upstream for enterprise support, there is a gap. This gap is where you (1) want to use an app ‘for real’, (2) need quick and efficient support with engineers, (3) but are not ready to commit yet to contracting with upstream. Our managed apps are our customers’ 'one hand to shake’ for all the many apps still within this gap.
+To help with these, we provide managed apps. When using open source tools, one has two choices. Either DIY or contract with enterprise upstream. Between these two, there is a gap. This gap is where you (1) want to use an app ‘for real’, (2) need quick and efficient support with engineers, (3) but don't have the use case yet to commit to contracting with upstream (if the option is even available). Our managed apps are our customers’ 'one hand to shake’ for all the many apps within this gap.
 
 ## Links
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ repository to track and adjust or charts maintained by Grafana Labs.
 
 Once your Kubernetes clusters are up and running, you can use dozens of apps to take control of every part of your cluster. For example, apps to configure DNS servers (External DNS), to generate and renew certificates (Cert Manager), to monitor (Prometheus), to log (EFK or Loki), and to trace (Jaeger) your workloads, to keep your clusters secure, to autoscale resources… and many more.
 
-To help with these, we provide managed apps. When using open source tools, one has two choices. Either DIY or contract with enterprise upstream. Between these two, there is a gap. This gap is where you (1) want to use an app ‘for real’, (2) need quick and efficient support with engineers, (3) but don't have the use case yet to commit to contracting with upstream (if the option is even available). Our managed apps are our customers’ 'one hand to shake’ for all the many apps within this gap.
+To help with these, we provide managed apps. When using open source tools, one has two choices. Either DIY or contract with upstream enterprise for support (if available). Between these two, there is a gap. This gap is where you (1) want to use an app ‘for real’, (2) need quick and efficient support with engineers, (3) but don't have the use case yet to commit to contract with upstream enterprise. Our managed apps are our customers’ 'one hand to shake’ for all the many apps within this gap.
 
 ## Links
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CircleCI](https://circleci.com/gh/giantswarm/loki-app.svg?style=shield)](https://circleci.com/gh/giantswarm/loki-app)
 
-This chart provides a distributed loki setup based on this
+Giant Swarm offers Loki as a managed app. This chart provides a distributed loki setup based on this
 [upstream chart](https://github.com/grafana/helm-charts/tree/main/charts/loki-distributed).
 It tunes a bunch of options from the upstream to make the chart easier to deploy.
 
@@ -140,6 +140,19 @@ AWS account.
 The source code in `helm/loki` is a git-subtree coming from the
 <https://github.com/giantswarm/grafana-helm-charts-upstream>. Giant Swarm uses that
 repository to track and adjust or charts maintained by Grafana Labs.
+
+## About Giant Swarm managed apps
+
+Once your Kubernetes clusters are up and running, you can use dozens of apps to take control of every part of your cluster. For example, apps to configure DNS servers (External DNS), to generate and renew certificates (Cert Manager), to monitor (Prometheus), to log (EFK or Loki), and to trace (Jaeger) your workloads, to keep your clusters secure, to autoscale resources… and many more.
+
+To help with these, we provide managed apps. Between DIY-ing open source tools and contracting with upstream for enterprise support, there is a gap. This gap is where you (1) want to use an app ‘for real’, (2) need quick and efficient support with engineers, (3) but are not ready to commit yet to contracting with upstream. Our managed apps are our customers’ 'one hand to shake’ for all the many apps still within this gap.
+
+## Links
+
+- [Loki demo for Giant Swarm customers (YouTube)](https://www.youtube.com/watch?v=KeJwfOiVA7o)
+- [Part 1: How the Cloud-Native Stack Helps Writing Minimal Microservices (blog series)](https://www.giantswarm.io/blog/how-the-cloud-native-stack-helps-writing-minimal-microservices/)
+- [Achieving cloud-native observability with open-source (on demand demo and slides)](https://www.giantswarm.io/on-demand-webinar-achieving-cloud-native-observability-with-open-source)
+- [The radical way Giant Swarm handles Service Level Objectives](https://www.giantswarm.io/blog/the-radical-way-giant-swarm-handles-service-level-objectives)
 
 ## Credit
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CircleCI](https://circleci.com/gh/giantswarm/loki-app.svg?style=shield)](https://circleci.com/gh/giantswarm/loki-app)
 
-Giant Swarm offers Loki as a managed app. This chart provides a distributed loki setup based on this
+Giant Swarm offers Loki as a [managed app](#about-giant-swarm-managed-apps). This chart provides a distributed loki setup based on this
 [upstream chart](https://github.com/grafana/helm-charts/tree/main/charts/loki-distributed).
 It tunes a bunch of options from the upstream to make the chart easier to deploy.
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ repository to track and adjust or charts maintained by Grafana Labs.
 
 Once your Kubernetes clusters are up and running, you can use dozens of apps to take control of every part of your cluster. For example, apps to configure DNS servers (External DNS), to generate and renew certificates (Cert Manager), to monitor (Prometheus), to log (EFK or Loki), and to trace (Jaeger) your workloads, to keep your clusters secure, to autoscale resources… and many more.
 
-To help with these, we provide managed apps. When using open source tools, one has two choices. Either DIY or contract with upstream enterprise for support (if available). Between these two, there is a gap. This gap is where you (1) want to use an app ‘for real’, (2) need quick and efficient support with engineers, (3) but don't have the use case yet to commit to contract with upstream enterprise. Our managed apps are our customers’ 'one hand to shake’ for all the many apps within this gap.
+To help with these, we provide managed apps. When using open source tools, one has two choices. Either DIY or contract with upstream enterprise for support (if available). Between these two, there is a gap. This gap is where you (1) want to use an app ‘for real’, (2) need quick and efficient support with engineers, (3) but don't have the use case yet to commit to contract with upstream enterprise. Our managed apps are our customers’ 'one hand to shake’ for the many apps in this gap.
 
 ## Links
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![CircleCI](https://circleci.com/gh/giantswarm/loki-app.svg?style=shield)](https://circleci.com/gh/giantswarm/loki-app)
 
-Giant Swarm offers Loki as a [managed app](#about-giant-swarm-managed-apps). This chart provides a distributed loki setup based on this
+Giant Swarm offers Loki as a [managed app](https://docs.giantswarm.io/changes/managed-apps/). This chart provides a distributed loki setup based on this
 [upstream chart](https://github.com/grafana/helm-charts/tree/main/charts/loki-distributed).
-It tunes a bunch of options from the upstream to make the chart easier to deploy.
+It tunes some options from upstream to make the chart easier to deploy.
 
 This chart is meant to be used with S3 compatible storage only. Access to the S3
 storage must be ensured for the chart to work. You can check
@@ -140,12 +140,6 @@ AWS account.
 The source code in `helm/loki` is a git-subtree coming from the
 <https://github.com/giantswarm/grafana-helm-charts-upstream>. Giant Swarm uses that
 repository to track and adjust or charts maintained by Grafana Labs.
-
-## About Giant Swarm managed apps
-
-Once your Kubernetes clusters are up and running, you can use dozens of apps to take control of every part of your cluster. For example, apps to configure DNS servers (External DNS), to generate and renew certificates (Cert Manager), to monitor (Prometheus), to log (EFK or Loki), and to trace (Jaeger) your workloads, to keep your clusters secure, to autoscale resources… and many more.
-
-To help with these, we provide managed apps. When using open source tools, one has two choices. Either DIY or contract with upstream enterprise for support (if available). Between these two, there is a gap. This gap is where you (1) want to use an app ‘for real’, (2) need quick and efficient support with engineers, (3) but don't have the use case yet to commit to contract with upstream enterprise. Our managed apps are our customers’ 'one hand to shake’ for the many apps in this gap.
 
 ## Links
 


### PR DESCRIPTION
Towards "Repackage and push the stuff we've created about Loki" in https://github.com/giantswarm/roadmap/issues/271

@giantswarm/team-halo 

1. I added section explaining managed apps in general - is it too 'promotional'? I tried to make it matter factual. I am also thinking the audience of this readme is customers. So it helps them understand how we see managed apps.
2. I will also suggest rendering this readme in https://docs.giantswarm.io/app-platform/apps/ under Loki. I think it would fit? 

Ping @giantswarm/sig-product-marketing and @HelloHeatherC as well...