### PR TITLE
Add giantswarm.io/monitoring_basic_sli label to StatefulSets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Basic SLI for ingester and querier StatefulSets
+
 ## [0.3.0] - 2021-07-09
 
 ### Added

--- a/helm/loki/templates/ingester/statefulset-ingester.yaml
+++ b/helm/loki/templates/ingester/statefulset-ingester.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "loki.ingesterLabels" . | nindent 4 }}
     app.kubernetes.io/part-of: memberlist
+    giantswarm.io/monitoring_basic_sli: "true"
 spec:
   replicas: {{ .Values.ingester.replicas }}
   podManagementPolicy: Parallel

--- a/helm/loki/templates/querier/statefulset-querier.yaml
+++ b/helm/loki/templates/querier/statefulset-querier.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "loki.querierLabels" . | nindent 4 }}
     app.kubernetes.io/part-of: memberlist
+    giantswarm.io/monitoring_basic_sli: "true"
 spec:
   replicas: {{ .Values.querier.replicas }}
   podManagementPolicy: Parallel


### PR DESCRIPTION
This PR adds the basic sli monitoring label to the ingester and querier labels