### PR TITLE
increase ingester probe initialDelay to 300s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Increase ingester probe initialDelay to 300 seconds
+
 ## [0.3.3] - 2021-11-04
 
 - Update app metadata

--- a/helm/loki/values.yaml
+++ b/helm/loki/values.yaml
@@ -40,13 +40,13 @@ loki:
     httpGet:
       path: /ready
       port: http
-    initialDelaySeconds: 30
+    initialDelaySeconds: 300
     timeoutSeconds: 1
   livenessProbe:
     httpGet:
       path: /ready
       port: http
-    initialDelaySeconds: 45
+    initialDelaySeconds: 300
   image:
     # -- The Docker registry
     registry: docker.io


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/20941

Startup time increase along with the amount of data to load at startup.

30s was clearly to low and lead to ingester being in `CrashLoopBackoff` state, 300s seems to be alright for now.

Data is currently 1MB and 60 indexes

<details>
   <summary>

```
/ $ du -sch /var/loki/index/*
```

</summary>

```
20.0K   /var/loki/index/loki_index_19002
28.0K   /var/loki/index/loki_index_19003
28.0K   /var/loki/index/loki_index_19004
24.0K   /var/loki/index/loki_index_19005
28.0K   /var/loki/index/loki_index_19006
28.0K   /var/loki/index/loki_index_19007
28.0K   /var/loki/index/loki_index_19008
28.0K   /var/loki/index/loki_index_19009
28.0K   /var/loki/index/loki_index_19010
32.0K   /var/loki/index/loki_index_19011
24.0K   /var/loki/index/loki_index_19012
24.0K   /var/loki/index/loki_index_19013
24.0K   /var/loki/index/loki_index_19014
32.0K   /var/loki/index/loki_index_19015
24.0K   /var/loki/index/loki_index_19016
24.0K   /var/loki/index/loki_index_19017
20.0K   /var/loki/index/loki_index_19018
20.0K   /var/loki/index/loki_index_19019
16.0K   /var/loki/index/loki_index_19020
16.0K   /var/loki/index/loki_index_19021
16.0K   /var/loki/index/loki_index_19022
12.0K   /var/loki/index/loki_index_19023
12.0K   /var/loki/index/loki_index_19024
12.0K   /var/loki/index/loki_index_19025
12.0K   /var/loki/index/loki_index_19026
12.0K   /var/loki/index/loki_index_19027
12.0K   /var/loki/index/loki_index_19028
12.0K   /var/loki/index/loki_index_19029
12.0K   /var/loki/index/loki_index_19030
12.0K   /var/loki/index/loki_index_19031
12.0K   /var/loki/index/loki_index_19032
12.0K   /var/loki/index/loki_index_19033
12.0K   /var/loki/index/loki_index_19034
12.0K   /var/loki/index/loki_index_19035
12.0K   /var/loki/index/loki_index_19036
12.0K   /var/loki/index/loki_index_19037
12.0K   /var/loki/index/loki_index_19038
12.0K   /var/loki/index/loki_index_19039
12.0K   /var/loki/index/loki_index_19040
20.0K   /var/loki/index/loki_index_19041
12.0K   /var/loki/index/loki_index_19042
12.0K   /var/loki/index/loki_index_19043
12.0K   /var/loki/index/loki_index_19044
12.0K   /var/loki/index/loki_index_19045
12.0K   /var/loki/index/loki_index_19046
12.0K   /var/loki/index/loki_index_19047
12.0K   /var/loki/index/loki_index_19048
12.0K   /var/loki/index/loki_index_19049
12.0K   /var/loki/index/loki_index_19050
4.0K    /var/loki/index/loki_index_19051
4.0K    /var/loki/index/loki_index_19052
4.0K    /var/loki/index/loki_index_19053
4.0K    /var/loki/index/loki_index_19054
12.0K   /var/loki/index/loki_index_19055
12.0K   /var/loki/index/loki_index_19056
4.0K    /var/loki/index/loki_index_19057
4.0K    /var/loki/index/loki_index_19058
4.0K    /var/loki/index/loki_index_19059
172.0K  /var/loki/index/loki_index_19060
8.0K    /var/loki/index/uploader
1.1M    total
```
</details>