### PR TITLE
liveness initialdelay: must be greater than readiness initialdelay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- startup crashloop due to incorrect initialDelay settings.
+
 ## [0.3.2] - 2022-03-09
 
 ### Fixed

--- a/helm/loki/values.yaml
+++ b/helm/loki/values.yaml
@@ -40,7 +40,7 @@ loki:
     httpGet:
       path: /ready
       port: http
-    initialDelaySeconds: 300
+    initialDelaySeconds: 30
     timeoutSeconds: 1
   livenessProbe:
     httpGet:


### PR DESCRIPTION
# TLDR
Liveness initialdelay: must be greater than readiness initialdelay to avoid crashloop at startup.

# Details
We don't much care about having a low readiness initialdelay: the risk is to have an invalid pod answering errors to requests, during startup phase.
On top of that, the "memberlist" servicediscovery mechanism (based on a headless service) requires a low readiness initialdelay, and setting it too high breaks discovery.

On the other hand, liveness initialdelay has to be high to avoid killing services during fetching of data for bigger Loki clusters.

Towards https://github.com/giantswarm/roadmap/issues/718