### PR TITLE
added metrics for read and write

### DIFF
--- a/helm/loki/templates/metrics.yaml
+++ b/helm/loki/templates/metrics.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    giantswarm.io/monitoring-port: http-metrics
+    giantswarm.io/monitoring-port: "3100"
   labels:
     giantswarm.io/monitoring: "true"
     app: {{ template "loki.name" . }}-read-metrics
@@ -27,7 +27,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    giantswarm.io/monitoring-port: http-metrics
+    giantswarm.io/monitoring-port: "3100"
   labels:
     giantswarm.io/monitoring: "true"
     app: {{ template "loki.name" . }}-write-metrics

--- a/helm/loki/templates/metrics.yaml
+++ b/helm/loki/templates/metrics.yaml
@@ -1,0 +1,47 @@
+# These services enable GiantSwarm's monitoring
+# from prometheus on the Management Cluster.
+{{- if .Values.giantswarm.labelmonitoring.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    giantswarm.io/monitoring-port: http-metrics
+  labels:
+    giantswarm.io/monitoring: "true"
+    app: {{ template "loki.name" . }}-read-metrics
+    {{ include "loki.labels" . | nindent 4 }}
+  name: {{ template "loki.name" . }}-read-metrics
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+  - name: http-metrics
+    port: 3100
+    targetPort: http-metrics
+  selector:
+    app.kubernetes.io/component: read
+    app.kubernetes.io/instance: {{ template "loki.name" . }}
+    app.kubernetes.io/name: {{ .Release.Name }}
+  type: "ClusterIP"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    giantswarm.io/monitoring-port: http-metrics
+  labels:
+    giantswarm.io/monitoring: "true"
+    app: {{ template "loki.name" . }}-write-metrics
+    {{ include "loki.labels" . | nindent 4 }}
+  name: {{ template "loki.name" . }}-write-metrics
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+  - name: http-metrics
+    port: 3100
+    targetPort: http-metrics
+  selector:
+    app.kubernetes.io/component: write
+    app.kubernetes.io/instance: {{ template "loki.name" . }}
+    app.kubernetes.io/name: {{ .Release.Name }}
+  type: "ClusterIP"
+{{- end }}

--- a/helm/loki/values.schema.json
+++ b/helm/loki/values.schema.json
@@ -2,6 +2,19 @@
     "$schema": "http://json-schema.org/schema#",
     "type": "object",
     "properties": {
+        "giantswarm": {
+            "type": "object",
+            "properties": {
+                "labelmonitoring": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        }
+                    }
+                }
+            }
+        },
         "global": {
             "type": "object",
             "properties": {

--- a/helm/loki/values.yaml
+++ b/helm/loki/values.yaml
@@ -29,6 +29,10 @@ multiTenantAuth:
 
 imagePullSecrets: []
 
+giantswarm:
+  labelmonitoring:
+    enabled: true
+
 global:
   image:
     # -- Overrides the Docker registry globally for all images


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/23523

Add metrics to the dependency-based chart.
It creates 2 additional services, with the label and annotation needed so that they are discovered and monitored by our MC setup.

Tested on gauss: works, we have our metrics. It successfully scrapes each pod of the service.
![image](https://user-images.githubusercontent.com/12008875/194907344-e63ba01a-01a4-4b39-aeb3-af5b00b53bde.png)

However, it also discovers the other port, and obviously fails scraping it.
![image](https://user-images.githubusercontent.com/12008875/194907907-a0daacd8-c9a9-4178-8f6e-7aa7a7746a14.png)
This means we have some faulty targets in Prometheus. Not very clean. :disappointed: 

Do you have some suggestions to make it better?