### PR TITLE
switch to gs-updated proxy

### DIFF
--- a/helm/loki/templates/multi-tenant-proxy/multi-tenant-proxy.yaml
+++ b/helm/loki/templates/multi-tenant-proxy/multi-tenant-proxy.yaml
@@ -78,6 +78,7 @@ spec:
             - "--port=3101"
             - '--loki-server=http://loki-write.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100'
             - "--auth-config=/etc/loki-multi-tenant-proxy/authn.yaml"
+            - "--keep-orgid"
           ports:
             - name: http-write
               containerPort: 3101

--- a/helm/loki/values.yaml
+++ b/helm/loki/values.yaml
@@ -2,8 +2,8 @@
 multiTenantAuth:
   enabled: false
   image:
-    repository: giantswarm/loki-multi-tenant-proxy
-    tag: v1.0.0
+    repository: giantswarm/loki-multi-tenant-proxy-gs
+    tag: 0.1.0
     pullPolicy: IfNotPresent
   replicas: 2
   credentials: |-
@@ -32,7 +32,7 @@ imagePullSecrets: []
 global:
   image:
     # -- Overrides the Docker registry globally for all images
-    registry: quay.io
+    registry: docker.io
   # -- Overrides the priorityClassName for all pods
   priorityClassName: null
   # -- configures cluster domain ("cluster.local" by default)
@@ -73,6 +73,8 @@ loki-upstream:
       requests:
         memory: 3072Mi
         cpu: 200m
+    extraArgs:
+      - -querier.multi-tenant-queries-enabled
 
   write:
     resources:


### PR DESCRIPTION
- use custom loki-multi-tenant-proxy
- don't overwrite org-id on the write path
- allow multi-tenant queries (setting orgid to `tenant1|tenant2`)
- use docker.io as default registry