### PR TITLE
rename loki-upstream to loki in values yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgrade Loki from 2.5.0 to 2.6.1
 - ⚠️  Major upgrade, breaking changes
   - PVCs change as we switch from distributed (ingester, compactor, distributor...) to simple-scalable (just read and write pods)
-  - values structure changes. We rely on a subchart, meaning most of previous setup goes to a `loki-upstream` section. See example files for extra info.
+  - values structure changes. We rely on a subchart, meaning most of previous setup goes to a `loki` section. See example files for extra info.
   - see UPGRADE.md for more info on how to upgrade
 
 

--- a/UPSTREAM_UPGRADE.md
+++ b/UPSTREAM_UPGRADE.md
@@ -1,6 +1,6 @@
 # Procedure for upstream upgrade
 
-* change the `loki-upstream` version in Chart dependencies (`helm/loki/Chart.yaml`)
+* change the `loki` upstream version in Chart dependencies (`helm/loki/Chart.yaml`)
 * re-generate `helm/loki/values.schema.json`:
   * `helm schema-gen helm/loki/values.yaml > helm/loki/values.schema.json` to re-generate the file.
   * `sed -i 's/"type": "null"/"type": ["string", "null"]/g' helm/loki/values.schema.json` to accept strings for all null values.

--- a/helm/loki/Chart.yaml
+++ b/helm/loki/Chart.yaml
@@ -11,9 +11,7 @@ sources:
 icon: https://s.giantswarm.io/app-icons/grafana-loki/2/dark.svg
 dependencies:
   - name: loki
-    alias: loki
     version: 3.0.7
-    # repository: file://../loki-upstream/
     repository: https://grafana.github.io/helm-charts
 maintainers:
   - name: Giant Swarm applications team

--- a/helm/loki/Chart.yaml
+++ b/helm/loki/Chart.yaml
@@ -11,7 +11,7 @@ sources:
 icon: https://s.giantswarm.io/app-icons/grafana-loki/2/dark.svg
 dependencies:
   - name: loki
-    alias: loki-upstream
+    alias: loki
     version: 3.0.7
     # repository: file://../loki-upstream/
     repository: https://grafana.github.io/helm-charts

--- a/helm/loki/values.schema.json
+++ b/helm/loki/values.schema.json
@@ -30,7 +30,7 @@
         "imagePullSecrets": {
             "type": "array"
         },
-        "loki-upstream": {
+        "loki": {
             "type": "object",
             "properties": {
                 "gateway": {

--- a/helm/loki/values.yaml
+++ b/helm/loki/values.yaml
@@ -55,7 +55,7 @@ serviceAccount:
   # -- Set this toggle to false to opt out of automounting API credentials for the service account
   automountServiceAccountToken: true
 
-loki-upstream:
+loki:
   gateway:
     replicas: 3
     deploymentStrategy:

--- a/sample_configs/values-gs-azure.yaml
+++ b/sample_configs/values-gs-azure.yaml
@@ -1,7 +1,4 @@
-global:
-  dnsService: "coredns"
-
-
+---
 multiTenantAuth:
   enabled: true
   replicas: 3
@@ -14,7 +11,7 @@ multiTenantAuth:
         password: 2tnaneT
         orgid: tenant-2
 
-loki-upstream:
+loki:
   # By default, Loki offers no authentication. It just expects the `X-Scope-OrgID`
   # HTTP header to be set to indicate which tenant's logs are these. To enable
   # minimal security, you can configure the gateway to route traffic through loki-multi-tenant-proxy

--- a/sample_configs/values-gs.yaml
+++ b/sample_configs/values-gs.yaml
@@ -1,9 +1,9 @@
 # /!\ Disclaimer: this example, is not tested at each update, we don't guarantee it works with the latest Loki charts
 #
-# by default, the k8s' DNS is named `kube-dns`; you might override it here
+# if your k8s' DNS is `kube-dns`; you might want to override it here
 # (please consult your cluster configuration for the correct value)
-global:
-  dnsService: "coredns"
+# global:
+#   dnsService: "coredns"
 
 multiTenantAuth:
   enabled: true
@@ -17,7 +17,7 @@ multiTenantAuth:
         password: 2tnaneT
         orgid: tenant-2
 
-loki-upstream:
+loki:
   # By default, Loki offers no authentication. It just expects the `X-Scope-OrgID`
   # HTTP header to be set to indicate which tenant's logs are these. To enable
   # minimal security, you can configure the gateway to route traffic through loki-multi-tenant-proxy


### PR DESCRIPTION
Rename `loki-upstream` to `loki` in `values yaml`, following @QuentinBisson's concerns here: https://github.com/giantswarm/loki-app/pull/114#discussion_r983556382

Tested locally with `helm template` and tested on `gauss`.

Towards https://github.com/giantswarm/giantswarm/issues/23523