### PR TITLE
upgrade chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* Upgraded upstream chart from 3.0.7 to 3.2.1 - see [changelog](https://github.com/grafana/loki/blob/main/production/helm/loki/CHANGELOG.md) for more information.
+
 ## [0.5.0] - 2022-10-13
 
 ### Changed

--- a/helm/loki/Chart.yaml
+++ b/helm/loki/Chart.yaml
@@ -11,7 +11,7 @@ sources:
 icon: https://s.giantswarm.io/app-icons/grafana-loki/2/dark.svg
 dependencies:
   - name: loki
-    version: 3.0.7
+    version: 3.2.1
     repository: https://grafana.github.io/helm-charts
 maintainers:
   - name: Giant Swarm applications team

--- a/helm/loki/values.schema.json
+++ b/helm/loki/values.schema.json
@@ -151,6 +151,14 @@
                                             "type": "boolean"
                                         }
                                     }
+                                },
+                                "lokiCanary": {
+                                    "type": "object",
+                                    "properties": {
+                                        "enabled": {
+                                            "type": "boolean"
+                                        }
+                                    }
                                 }
                             }
                         },

--- a/helm/loki/values.yaml
+++ b/helm/loki/values.yaml
@@ -113,3 +113,5 @@ loki:
       enabled: false
       grafanaAgent:
         installOperator: false
+      lokiCanary:
+        enabled: false

--- a/sample_configs/values-gs.yaml
+++ b/sample_configs/values-gs.yaml
@@ -130,6 +130,14 @@ loki:
               proxy_pass       http://loki-multi-tenant-proxy.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
             }
 
+            location ~ /prometheus/api/v1/alerts.* {
+              proxy_pass       http://loki-multi-tenant-proxy.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+            }
+
+            location ~ /prometheus/api/v1/rules.* {
+              proxy_pass       http://loki-multi-tenant-proxy.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+            }
+
             location = /loki/api/v1/push {
               proxy_pass       http://loki-multi-tenant-proxy.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3101$request_uri;
             }


### PR DESCRIPTION
* Upgraded upstream chart from 3.0.7 to 3.2.1 - see [changelog](https://github.com/grafana/loki/blob/main/production/helm/loki/CHANGELOG.md) for more information.