### PR TITLE
Add icon to Chart.yaml for happa

### DIFF
--- a/helm/loki/Chart.yaml
+++ b/helm/loki/Chart.yaml
@@ -10,7 +10,7 @@ sources:
   - https://grafana.com/oss/loki/
   - https://grafana.com/docs/loki/latest/
   - https://grafana.github.io/helm-charts
-icon: https://s.giantswarm.io/app-icons/grafana-loki/2/dark.svg
+icon: https://s.giantswarm.io/app-icons/loki-stack/1/dark.svg
 upstreamChartURL: https://github.com/grafana/helm-charts/
 upstreamChartVersion: loki-distributed-0.49.0
 maintainers:
@@ -21,3 +21,4 @@ restrictions:
   namespaceSingleton: true
 annotations:
   application.giantswarm.io/team: "atlas"
+  ui.giantswarm.io/logo: https://s.giantswarm.io/app-icons/grafana-loki/2/dark.svg


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1248

Don't be confused by `loki-stack`. We are reusing existing assets.