### PR TITLE
improve upgrade path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Chart info: maintainers
 - Chart info: icon
+- Improve upgrade path from 0.4 to 0.5
 
 ## [0.5.1] - 2022-10-25
 
@@ -27,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ⚠️  Major upgrade, breaking changes
   - PVCs change as we switch from distributed (ingester, compactor, distributor...) to simple-scalable (just read and write pods)
   - values structure changes. We rely on a subchart, meaning most of previous setup goes to a `loki` section. See example files for extra info.
-  - see UPGRADE.md for more info on how to upgrade
+  - see (UPGRADE.md)[https://github.com/giantswarm/loki-app/blob/release-v0.5.x/UPGRADE.md#procedure-to-upgrade-from-loki-app-v04x-to-v05x] for more info on how to upgrade
 
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ storage must be ensured for the chart to work.
 * Check [below](#deploying-on-aws) to see what configuration you need on the AWS side.
 * or [below](#deploying-on-azure) to see what configuration you need on the Azure side.
 
+⚠️ Make sure to read (upgrade guide)[https://github.com/giantswarm/loki-app/blob/master/UPGRADE.md] to check breaking changes before performing an upgrade
+
 
 ## Requirements
 
@@ -339,7 +341,7 @@ The source code in `helm/loki` is a git-subtree coming from the
 <https://github.com/giantswarm/grafana-helm-charts-upstream>. Giant Swarm uses that
 repository to track and adjust or charts maintained by Grafana Labs.
 
-Notes specific to upstream upgrade can be found in UPSTREAM_UPGRADE.md
+Notes specific to upstream upgrade can be found in (UPGRADE.md)[https://github.com/giantswarm/loki-app/blob/master/UPGRADE.md]
 
 ## Links
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,32 +8,47 @@
    * for manual/happa deployments you could do it with a command like `k get cm -n [mycluster] loki-user-values -oyaml | yq '.data.values'` on the management cluster
    * for gitops deployments, you should have it in git
 1. keep a backup: `cp values.yaml values.yaml_0.4`
-1. prepare your new values file
+1. prepare your new values file (see "Most notable changes" section hereafter for details on what to change)
 1. open grafana, check that you can access your logs
 1. uninstall loki
 1. install newer loki version, with new values
 1. check in grafana that you can still access old and new logs
 
-To be tested when we have old and new loki in the same catalog: upgrade without uninstalling.
+__Note:__
 
-## Notes:
+Uninstalling before re-installing is not mandatory. You can also change config and app version at the same time. Works well with Flux for instance.
+
+## Details
 
 ### Your `values.yaml` file need some adjustments.
 
 Most notable changes:
 * We changed the base chart from [loki-distributed](https://github.com/grafana/helm-charts/tree/main/charts/loki-distributed) to [loki (ex simple-scalable)](https://github.com/grafana/loki/tree/main/production/helm/loki)
 * The change of chart leads to a change of achitecture. The component's names are not the same, and the persistent volumes change. A bit of recent data may be lost in the migration.
-* We switched to using a subchart. This changes the layout of your `values.yaml`, as all upstream-specific configuration will be set in a `loki` subtree. See example `values` files.
+* We switched to using a subchart. This changes the layout of your `values.yaml`:
+  * most of the settings are moving under a `loki` section. Actually that's all the upstream-specific chart configuration.
+  * except what is not specific to upstream chart, like `global`, `multiTenantAuth`, `imagePullSecrets` and `giantswarm` settings
+  * note that you will probably have a `loki` section inside another `loki` section
+* You can look at the default and sample `values` files to understand the changes:
+  * with `loki-app` v0.4.x:
+    * [upstream values (loki-distributed 0.48.5)](https://github.com/grafana/helm-charts/blob/loki-distributed-0.48.5/charts/loki-distributed/values.yaml)
+    * [default giantswarm values](https://github.com/giantswarm/loki-app/blob/3d777f261a7f820721c6732295aab56c809f4281/helm/loki/values.yaml)
+    * [giantswarm sample configs](https://github.com/giantswarm/loki-app/blob/3d777f261a7f820721c6732295aab56c809f4281/sample_configs/values-gs.yaml)
+  * with `loki-app` v0.5.x:
+    * [upstream values (official loki 3.2.1)](https://github.com/grafana/loki/blob/helm-loki-3.2.1/production/helm/loki/values.yaml)
+    * [giantswarm default values](https://github.com/giantswarm/loki-app/blob/release-v0.5.x/helm/loki/values.yaml)
+    * [giantswarm sample configs](https://github.com/giantswarm/loki-app/tree/release-v0.5.x/sample_configs)
 
 ### New Loki defaults to multi-tenant mode.
 
 If you set an orgid when sending logs, you now have to make sure you set it also when reading logs.
 You can read multiple tenants with orgid built like this: `tenant1|tenant2`
 Logs sent with no tenant are stored as tenant `fake`.
-You can see all your tenants by listing your object storage. Here, I have `fake` and `gauss` tenants:
+You can see all your tenants by listing your object storage. Here, I have `fake`, `tenant1` and `tenant2` tenants:
 ```
 fake/
-gauss/
+tenant1/
+tenant2/
 index/
 loki_cluster_seed.json
 ```


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/24640

Improve upgrade documentation for customers.
Once we are happy with it we can push this release to  GA.

Links are broken in `README` because I set the (expected) address after merge.
Has to be an absolute URL to work from Happa.

Note to reviewers: please also read the `UPGRADE` guide, and tell me if anything is missing.