### PR TITLE
push to public catalog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,11 +7,10 @@ workflows:
     jobs:
       - architect/push-to-app-catalog:
           context: "architect"
-          # app-build-suite breaks on "application.giantswarm.io/team" in _helpers test
           executor: "app-build-suite"
           name: "package and push loki chart"
-          app_catalog: "giantswarm-playground-catalog"
-          app_catalog_test: "giantswarm-playground-test-catalog"
+          app_catalog: "giantswarm-catalog"
+          app_catalog_test: "giantswarm-test-catalog"
           chart: "loki"
           ct_config: ".circleci/ct-config.yaml"
           # Trigger job on git tag.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed:
 
 - CI: use app-build-suite again
+- Push Loki SSD (new chart) to public catalogs
 
 ### Fixed
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/24640

Push again to public catalog, so loki SSD is available to customers starting from next release.