### PR TITLE
Value to disable deploying loki

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Added `.loki.enabled` in values so we can disable Loki by changing the values
 - Added documentation concerning the use of IRSA in README.
 
 ## [0.9.0] - 2023-05-15

--- a/helm/loki/Chart.lock
+++ b/helm/loki/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: loki
   repository: https://grafana.github.io/helm-charts
   version: 5.5.0
-digest: sha256:eb0f1f61a5564a32d6e6aaa097de22e4d659d7b43df6e3060c5ba1494da6407d
-generated: "2023-05-03T15:13:16.724340314Z"
+digest: sha256:dcbb55c6eac52c36ab4f4a3a23c393e7854e08534024edd13fcc38ce0666f490
+generated: "2023-06-05T23:07:34.193471998+02:00"

--- a/helm/loki/Chart.yaml
+++ b/helm/loki/Chart.yaml
@@ -13,6 +13,7 @@ dependencies:
   - name: loki
     version: 5.5.0
     repository: https://grafana.github.io/helm-charts
+    condition: loki.enabled
 maintainers:
   - name: giantswarm/team-atlas
     email: team-atlas@giantswarm.io

--- a/helm/loki/templates/metrics.yaml
+++ b/helm/loki/templates/metrics.yaml
@@ -1,5 +1,6 @@
 # These services enable GiantSwarm's monitoring
 # from prometheus on the Management Cluster.
+{{- if .Values.loki.enabled }}
 {{- if .Values.giantswarm.labelmonitoring.enabled }}
 apiVersion: v1
 kind: Service
@@ -44,4 +45,5 @@ spec:
     app.kubernetes.io/instance: {{ template "loki.name" . }}
     app.kubernetes.io/name: {{ .Release.Name }}
   type: "ClusterIP"
+{{- end }}
 {{- end }}

--- a/helm/loki/templates/multi-tenant-proxy/hpa.yaml
+++ b/helm/loki/templates/multi-tenant-proxy/hpa.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.loki.enabled }}
 {{- if .Values.multiTenantAuth.enabled }}
 {{- $autoscalingv2 := .Capabilities.APIVersions.Has "autoscaling/v2" -}}
 {{- if .Values.multiTenantAuth.autoscaling.enabled }}
@@ -44,5 +45,6 @@ spec:
         targetAverageUtilization: {{ . }}
         {{- end }}
   {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/helm/loki/templates/multi-tenant-proxy/multi-tenant-proxy.yaml
+++ b/helm/loki/templates/multi-tenant-proxy/multi-tenant-proxy.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.loki.enabled }}
 {{- if .Values.multiTenantAuth.enabled }}
 apiVersion: v1
 kind: Secret
@@ -117,4 +118,5 @@ spec:
         - name: config
           secret:
             secretName: loki-multi-tenant-proxy-auth-config
+{{- end }}
 {{- end }}

--- a/helm/loki/values.schema.json
+++ b/helm/loki/values.schema.json
@@ -46,9 +46,20 @@
         "loki": {
             "type": "object",
             "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
                 "gateway": {
                     "type": "object",
                     "properties": {
+                        "autoscaling": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                }
+                            }
+                        },
                         "deploymentStrategy": {
                             "type": "object",
                             "properties": {
@@ -78,6 +89,14 @@
                         },
                         "replicas": {
                             "type": "integer"
+                        },
+                        "nginxConfig": {
+                            "type": "object",
+                            "properties": {
+                                "genMultiTenant": {
+                                    "type": "boolean"
+                                }
+                            }
                         }
                     }
                 },
@@ -123,6 +142,14 @@
                             }
                         },
                         "dashboards": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                }
+                            }
+                        },
+                        "lokiCanary": {
                             "type": "object",
                             "properties": {
                                 "enabled": {
@@ -215,6 +242,14 @@
                         }
                     }
                 },
+                "test": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        }
+                    }
+                },
                 "write": {
                     "type": "object",
                     "properties": {
@@ -249,6 +284,26 @@
         "multiTenantAuth": {
             "type": "object",
             "properties": {
+                "autoscaling": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "maxReplicas": {
+                            "type": "integer"
+                        },
+                        "minReplicas": {
+                            "type": "integer"
+                        },
+                        "targetCPUUtilizationPercentage": {
+                            "type": "integer"
+                        },
+                        "targetMemoryUtilizationPercentage": {
+                            "type": ["string", "null"]
+                        }
+                    }
+                },
                 "containerSecurityContext": {
                     "type": "object",
                     "properties": {
@@ -310,6 +365,30 @@
                 },
                 "replicas": {
                     "type": "integer"
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "properties": {
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string"
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
                 }
             }
         },

--- a/helm/loki/values.yaml
+++ b/helm/loki/values.yaml
@@ -82,6 +82,8 @@ serviceAccount:
   automountServiceAccountToken: true
 
 loki:
+  # You can make the whole chart ineffective by setting this one to "false"
+  enabled: true
   gateway:
     nginxConfig:
       genMultiTenant: false


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1840

To enable disabling Loki for some specific install via the values (in `config` repo),
this PR adds `.loki.enabled` in Values file.

I also updated values schema which apparently was a bit outdated.