### PR TITLE
Gateway HPA defaults to minimum 2 replicas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+
+- Gateway HPA defaults to minimum 2 replicas
+- Added `.loki.enabled` in values so we can disable Loki by changing the values
+
 ## [0.9.1] - 2023-05-17
 
 ### Changed
 
-- Added `.loki.enabled` in values so we can disable Loki by changing the values
 - Added documentation concerning the use of IRSA in README.
 
 ## [0.9.0] - 2023-05-15

--- a/helm/loki/values.yaml
+++ b/helm/loki/values.yaml
@@ -93,6 +93,7 @@ loki:
       #customBackendUrl: http://loki-multi-tenant-proxy.default.svc.cluster.local:3102
     autoscaling:
       enabled: true
+      minReplicas: 2
     deploymentStrategy:
       type: RollingUpdate
       rollingUpdate:


### PR DESCRIPTION
Fix towards https://github.com/giantswarm/roadmap/issues/2365

HPA was only setting 1 gateway pod at minimum, we want 2 for HA.

+ fix changelog