### PR TITLE
multi-tenant-proxy: homogeneization of deployment labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded upstream chart from 5.5.0 to 5.6.4 - see [changelog](https://github.com/grafana/loki/blob/main/production/helm/loki/CHANGELOG.md) for more information.
 - Gateway HPA defaults to minimum 2 replicas
 - Added `.loki.enabled` in values so we can disable Loki by changing the values
+- multi-tenant-proxy: homogeneization of deployment labels
 
 ## [0.9.1] - 2023-05-17
 

--- a/helm/loki/templates/multi-tenant-proxy/multi-tenant-proxy.yaml
+++ b/helm/loki/templates/multi-tenant-proxy/multi-tenant-proxy.yaml
@@ -6,6 +6,7 @@ metadata:
   name: loki-multi-tenant-proxy-auth-config
   labels:
     app: loki-multi-tenant-proxy
+    app.kubernetes.io/component: loki-multi-tenant-proxy
     {{- include "loki.labels" . | nindent 4 }}
 data:
   authn.yaml: {{ .Values.multiTenantAuth.credentials | b64enc }}


### PR DESCRIPTION
...so it has comparable labels with other Loki deployments / pods.