### PR TITLE
pushing to AWS collection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,3 +17,17 @@ workflows:
           filters:
             tags:
               only: /^v.*/
+
+      - architect/push-to-app-collection:
+          context: "architect"
+          name: aws-app-collection
+          app_name: "loki"
+          app_namespace: "loki"
+          app_collection_repo: "aws-app-collection"
+          requires:
+            - "package and push loki chart"
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adjusted resources requests/limits for `read`, `backend` and `gateway` components
 - enabled HPA for read, write and backend
 - multi-tenant-proxy: homogeneization of deployment labels
+- Pushing to AWS collection
 
 ## [0.9.1] - 2023-05-17
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1840

To be merged (and released) only after https://github.com/giantswarm/config/pull/1789 is merged, to control deployment. Otherwise would deploy on all AWS installation with the repo's default config, which would not work.