### PR TITLE
sample configs: fix KIAM config

### DIFF
--- a/sample_configs/values-gs.yaml
+++ b/sample_configs/values-gs.yaml
@@ -78,9 +78,11 @@ loki:
       # and means that pods having it can use this IAM Role for S3 access
       iam.amazonaws.com/role: gs-loki-storage-m2h60-role
 
-  # giantswarm.io/machine-deployment ids (hon60) below reference the node pool ids
-  # replace them with your ids of your node pools
-
+  # propagate KIAM annotations
   write: *shared-conf
 
+  # propagate KIAM annotations
   read: *shared-conf
+
+  # propagate KIAM annotations
+  backend: *shared-conf


### PR DESCRIPTION
kiam config was broken when using the 3-targets config (with a `backend` statefulset).
This change in the sample config should help us and users figure it out.