### PR TITLE
Fix pod security standard for loki backend sidecar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix loki-backend sidecar pod security standard violations.
+
 ## [0.12.2] - 2023-09-26
 
 ### Changed

--- a/helm/loki/values.schema.json
+++ b/helm/loki/values.schema.json
@@ -368,6 +368,14 @@
                 "rbac": {
                     "type": "object",
                     "properties": {
+                        "pspAnnotations": {
+                            "type": "object",
+                            "properties": {
+                                "seccomp.security.alpha.kubernetes.io/allowedProfileNames": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "pspEnabled": {
                             "type": "boolean"
                         }
@@ -411,6 +419,49 @@
                                             "type": "string"
                                         },
                                         "memory": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "sidecar": {
+                    "type": "object",
+                    "properties": {
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "repository": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "securityContext": {
+                            "type": "object",
+                            "properties": {
+                                "allowPrivilegeEscalation": {
+                                    "type": "boolean"
+                                },
+                                "capabilities": {
+                                    "type": "object",
+                                    "properties": {
+                                        "drop": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                },
+                                "readOnlyRootFilesystem": {
+                                    "type": "boolean"
+                                },
+                                "seccompProfile": {
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
                                             "type": "string"
                                         }
                                     }

--- a/helm/loki/values.yaml
+++ b/helm/loki/values.yaml
@@ -211,5 +211,17 @@ loki:
     lokiCanary:
       enabled: false
 
+  sidecar:
+    image:
+      repository: giantswarm/k8s-sidecar
+    securityContext:
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+          - ALL
+      allowPrivilegeEscalation: false
+      seccompProfile:
+        type: RuntimeDefault
+
   test:
     enabled: false


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/28412 and following on https://github.com/giantswarm/retagger/pull/882

In the latest versions of the loki chart, the loki-backend is now equipped with a sidecar, let's fix it so it respects the pod security standard