### PR TITLE
multi-tenant-proxy: enforce write orgid according to the user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded upstream chart from 5.29.0 to 5.34.0 - see [changelog](https://github.com/grafana/loki/blob/main/production/helm/loki/CHANGELOG.md) for more information.
 - Upgraded loki from 2.9.1 to 2.9.2 - see [changelog](https://github.com/grafana/loki/blob/main/CHANGELOG.md) for more information.
 - Resource usage improvements (requests and limits, and HPA tuning)
-- multi-tenant-proxy: enforce org-id according to the user
+- multi-tenant-proxy: enforce org-id according to the user - can be changed back with `.Values.multiTenantAuth.write.enforceOrgId`
 
 ## [0.13.0] - 2023-10-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded upstream chart from 5.29.0 to 5.34.0 - see [changelog](https://github.com/grafana/loki/blob/main/production/helm/loki/CHANGELOG.md) for more information.
 - Upgraded loki from 2.9.1 to 2.9.2 - see [changelog](https://github.com/grafana/loki/blob/main/CHANGELOG.md) for more information.
 - Resource usage improvements (requests and limits, and HPA tuning)
+- multi-tenant-proxy: enforce org-id according to the user
 
 ## [0.13.0] - 2023-10-17
 

--- a/helm/loki/templates/multi-tenant-proxy/multi-tenant-proxy.yaml
+++ b/helm/loki/templates/multi-tenant-proxy/multi-tenant-proxy.yaml
@@ -86,6 +86,9 @@ spec:
             - "--port=3101"
             - '--loki-server=http://loki-write.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100'
             - "--auth-config=/etc/loki-multi-tenant-proxy/authn.yaml"
+            {{- if not .Values.multiTenantAuth.write.enforceOrgId }}
+            - "--keep-orgid"
+            {{- end }}
           ports:
             - name: http-write
               containerPort: 3101

--- a/helm/loki/templates/multi-tenant-proxy/multi-tenant-proxy.yaml
+++ b/helm/loki/templates/multi-tenant-proxy/multi-tenant-proxy.yaml
@@ -86,7 +86,6 @@ spec:
             - "--port=3101"
             - '--loki-server=http://loki-write.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100'
             - "--auth-config=/etc/loki-multi-tenant-proxy/authn.yaml"
-            - "--keep-orgid"
           ports:
             - name: http-write
               containerPort: 3101

--- a/helm/loki/values.yaml
+++ b/helm/loki/values.yaml
@@ -53,6 +53,9 @@ multiTenantAuth:
     readOnlyRootFilesystem: true
     seccompProfile:
       type: RuntimeDefault
+  write:
+    # -- disabling this allows write requests to set whatever orgid they want
+    enforceOrgId: true
 
 global:
   image:


### PR DESCRIPTION
Now that logging-operator configures the user/orgid for each cluster, we can set multi-tenant-proxy to enforce orgid based on authenticated user.