### PR TITLE
multi-tenant-proxy: toggle for credentials provisioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded upstream chart from 5.29.0 to 5.34.0 - see [changelog](https://github.com/grafana/loki/blob/main/production/helm/loki/CHANGELOG.md) for more information.
 - Upgraded loki from 2.9.1 to 2.9.2 - see [changelog](https://github.com/grafana/loki/blob/main/CHANGELOG.md) for more information.
 - Resource usage improvements (requests and limits, and HPA tuning)
+- multi-tenant-proxy: toggle for credentials provisioning
 
 ## [0.13.0] - 2023-10-17
 

--- a/helm/loki/templates/multi-tenant-proxy/multi-tenant-proxy.yaml
+++ b/helm/loki/templates/multi-tenant-proxy/multi-tenant-proxy.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.loki.enabled }}
 {{- if .Values.multiTenantAuth.enabled }}
+{{- if .Values.multiTenantAuth.deployCredentials }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,6 +11,7 @@ metadata:
     {{- include "loki.labels" . | nindent 4 }}
 data:
   authn.yaml: {{ .Values.multiTenantAuth.credentials | b64enc }}
+{{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/helm/loki/values.yaml
+++ b/helm/loki/values.yaml
@@ -29,6 +29,8 @@ multiTenantAuth:
     requests:
       memory: 50Mi
       cpu: 50m
+  # disable if credentials are provided externally
+  deployCredentials: true
   credentials: |-
     users:
       - username: Tenant1


### PR DESCRIPTION
Add a toggle to disable creation of loki-multi-tenant credentials.
Useful when an external tool is creating / updating them (like logging-operator :wink: ) so it does not get overwritten.