### PR TITLE
push to capvcd

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,3 +72,17 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v.*/
+
+      - architect/push-to-app-collection:
+          context: "architect"
+          name: cloud-director-app-collection
+          app_name: "loki"
+          app_namespace: "loki"
+          app_collection_repo: "cloud-director-app-collection"
+          requires:
+            - "package and push loki chart to control-plane-catalogs"
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded upstream chart from 5.37.0 to 5.39.0 - see [changelog](https://github.com/grafana/loki/blob/main/production/helm/loki/CHANGELOG.md) for more information.
 - Moved `serviceAccount` field in the `loki` section in the values.
 - push to capz collection
+- push to CAPVCD collection
 
 ## [0.14.4] - 2023-11-22
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2944

Push loki to capvcd collection.
By default, logging is disabled, and loki resources won't be actually deployed until we enable logging on installations.