### PR TITLE
fix HPAs by setting resource requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- rules sidecar resources fixed (fixes backend HPA)
-- resources set for dnsmasq sidecar (fixes gateway HPA)
+- Fix requests/limits for sidecar container (fixes backend HPA)
+- Add requests/limits for dnsmasq container (fixes gateway HPA)
 
 ## [0.14.5] - 2023-12-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- rules sidecar resources fixed (fixes backend HPA)
+- resources set for dnsmasq sidecar (fixes gateway HPA)
+
 ## [0.14.5] - 2023-12-04
 
 ### Changed

--- a/helm/loki/values.yaml
+++ b/helm/loki/values.yaml
@@ -110,6 +110,12 @@ loki:
           allowPrivilegeEscalation: false
           seccompProfile:
             type: RuntimeDefault
+        resources:
+          limits:
+            memory: 100Mi
+          requests:
+            cpu: 10m
+            memory: 10Mi
     nginxConfig:
       resolver: "127.0.0.1:8053 valid=60s"
       genMultiTenant: false
@@ -190,16 +196,6 @@ loki:
         memory: 3Gi
         cpu: 500m
 
-  # Rules sidecar for backend
-  sidecar:
-    resources:
-      limits:
-        cpu: 100m
-        memory: 100Mi
-      requests:
-        cpu: 50m
-        memory: 50Mi
-
   loki:
     image:
       repository: giantswarm/loki
@@ -271,6 +267,13 @@ loki:
       allowPrivilegeEscalation: false
       seccompProfile:
         type: RuntimeDefault
+    resources:
+      limits:
+        cpu: 100m
+        memory: 100Mi
+      requests:
+        cpu: 50m
+        memory: 50Mi
 
   test:
     enabled: false


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/29149

### Backend HPA:

Resources definition for the ruler were broken because the `sidecar` section was defined twice in default values.
Now both definitions are merged.

### Gateway HPA

Added resources request for dnsmasq sidecar