### PR TITLE
Fix loki installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix loki installation app installation failing when loki is disabled.
+
 ## [0.14.9] - 2024-01-15
 
 ### Added

--- a/helm/loki/templates/minio/minio-ciliumnetworkpolicy.yaml
+++ b/helm/loki/templates/minio/minio-ciliumnetworkpolicy.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.loki.enabled }}
 {{- if .Values.loki.minio.enabled -}}
 {{- if .Values.ciliumNetworkPolicy.enabled -}}
 apiVersion: cilium.io/v2
@@ -17,5 +18,6 @@ spec:
     - ports:
       - port: "9000"
         protocol: TCP
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/helm/loki/templates/minio/minio-networkpolicy.yaml
+++ b/helm/loki/templates/minio/minio-networkpolicy.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.loki.enabled }}
 {{- if .Values.loki.minio.enabled -}}
 {{- if not .Values.ciliumNetworkPolicy.enabled -}}
 apiVersion: networking.k8s.io/v1
@@ -18,5 +19,6 @@ spec:
   policyTypes:
   - Egress
   - Ingress
+{{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
Loki App is failing on installations where it's disabled:

```
 reason: 'template: loki/templates/minio/minio-networkpolicy.yaml:1:14: executing
      "loki/templates/minio/minio-networkpolicy.yaml" at <.Values.loki.minio.enabled>:
      nil pointer evaluating interface {}.enabled'
```


This fix addresses that by only deploying minio network policies if Loki is deployed