### PR TITLE
Add environment variables to loki-multi-tenant-proxy (OAUTH_URL)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Upgraded upstream chart from 5.41.4 to 5.41.8 - see [changelog](https://github.com/grafana/loki/blob/main/production/helm/loki/CHANGELOG.md) for more information.
+- Add environment variables to loki-multi-tenant-proxy (OAUTH_URL).
 
 ## [0.14.11] - 2024-01-22
 

--- a/helm/loki/templates/multi-tenant-proxy/multi-tenant-proxy.yaml
+++ b/helm/loki/templates/multi-tenant-proxy/multi-tenant-proxy.yaml
@@ -70,6 +70,10 @@ spec:
             - '--loki-server=http://loki-read.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100'
             - "--auth-config=/etc/loki-multi-tenant-proxy/authn.yaml"
             - "--log-level=WARN"
+          {{- with .Values.multiTenantAuth.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http-read
               containerPort: 3100
@@ -93,6 +97,10 @@ spec:
             {{- if not .Values.multiTenantAuth.write.enforceOrgId }}
             - "--keep-orgid"
             {{- end }}
+          {{- with .Values.multiTenantAuth.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http-write
               containerPort: 3101
@@ -113,6 +121,10 @@ spec:
             - '--loki-server=http://loki-backend.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100'
             - "--auth-config=/etc/loki-multi-tenant-proxy/authn.yaml"
             - "--log-level=WARN"
+          {{- with .Values.multiTenantAuth.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http-backend
               containerPort: 3102

--- a/helm/loki/values.yaml
+++ b/helm/loki/values.yaml
@@ -21,6 +21,8 @@ multiTenantAuth:
     tag: 0.2.0
     pullPolicy: IfNotPresent
     pullSecrets: []
+  # Environment variables for the multi-tenant proxy
+  # env: []
   # -- Resource requests and limits for the write
   resources:
     limits:


### PR DESCRIPTION
towards https://github.com/giantswarm/roadmap/issues/1131

Add OAUTH_URL as an environment variable to loki-multi-tenant-proxy to be able to validate the issuer into the oauth token forwarded by Grafana.