### PR TITLE
Fix mtp labels and split the proxy into multiple files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Auto reload multi-tenant-proxy config when it changes.
 - Upgraded upstream chart from 5.43.1 to 5.43.2 - see [changelog](https://github.com/grafana/loki/blob/main/production/helm/loki/CHANGELOG.md) for more information.
 
+### Fixed
+
+- Fix multi-tenant-proxy labels to be able to use the ciliumnetworkpolicies and to align with the other components.
+
 ## [0.15.3] - 2024-02-15
 
 ### Added

--- a/helm/loki/templates/multi-tenant-proxy/_helpers-proxy.tpl
+++ b/helm/loki/templates/multi-tenant-proxy/_helpers-proxy.tpl
@@ -1,0 +1,15 @@
+{{/*
+multi-tenant-proxy common labels
+*/}}
+{{- define "loki.multiTenantProxyLabels" -}}
+{{ include "loki.labels" . }}
+app.kubernetes.io/component: multi-tenant-proxy
+{{- end }}
+
+{{/*
+multi-tenant-proxy selector labels
+*/}}
+{{- define "loki.multiTenantProxySelectorLabels" -}}
+{{ include "loki.selectorLabels" . }}
+app.kubernetes.io/component: multi-tenant-proxy
+{{- end }}

--- a/helm/loki/templates/multi-tenant-proxy/auth-config-secret.yaml
+++ b/helm/loki/templates/multi-tenant-proxy/auth-config-secret.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.loki.enabled }}
+{{- if .Values.multiTenantAuth.enabled }}
+{{- if .Values.multiTenantAuth.deployCredentials }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: loki-multi-tenant-proxy-auth-config
+  labels:
+    {{- include "loki.multiTenantProxyLabels" . | nindent 4 }}
+data:
+  authn.yaml: {{ .Values.multiTenantAuth.credentials | b64enc }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm/loki/templates/multi-tenant-proxy/deployment.yaml
+++ b/helm/loki/templates/multi-tenant-proxy/deployment.yaml
@@ -1,57 +1,23 @@
 {{- if .Values.loki.enabled }}
 {{- if .Values.multiTenantAuth.enabled }}
-{{- if .Values.multiTenantAuth.deployCredentials }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: loki-multi-tenant-proxy-auth-config
-  labels:
-    app: loki-multi-tenant-proxy
-    app.kubernetes.io/component: loki-multi-tenant-proxy
-    {{- include "loki.labels" . | nindent 4 }}
-data:
-  authn.yaml: {{ .Values.multiTenantAuth.credentials | b64enc }}
-{{- end }}
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: loki-multi-tenant-proxy
-spec:
-  ports:
-  - port: 3100
-    protocol: TCP
-    name: http-read
-  - port: 3101
-    protocol: TCP
-    name: http-write
-  - port: 3102
-    protocol: TCP
-    name: http-backend
-  selector:
-    app: loki-multi-tenant-proxy
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  labels:
-    app: loki-multi-tenant-proxy
-    giantswarm.io/service-type: "managed"
-    giantswarm.io/monitoring_basic_sli: "true"
-    {{- include "loki.labels" . | nindent 4 }}
   name: loki-multi-tenant-proxy
+  labels:
+    {{- include "loki.multiTenantProxyLabels" . | nindent 4 }}
 spec:
 {{- if not .Values.multiTenantAuth.autoscaling.enabled }}
   replicas: {{ .Values.multiTenantAuth.replicas }}
 {{- end }}
   selector:
     matchLabels:
-      app: loki-multi-tenant-proxy
+      {{- include "loki.multiTenantProxySelectorLabels" . | nindent 6 }}
   strategy: {}
   template:
     metadata:
       labels:
-        app: loki-multi-tenant-proxy
+        {{- include "loki.multiTenantProxyLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ .Values.loki.serviceAccount.name }}
       {{- with .Values.multiTenantAuth.image.pullSecrets }}

--- a/helm/loki/templates/multi-tenant-proxy/hpa.yaml
+++ b/helm/loki/templates/multi-tenant-proxy/hpa.yaml
@@ -11,8 +11,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: loki-multi-tenant-proxy
   labels:
-    app: loki-multi-tenant-proxy
-    {{- include "loki.labels" . | nindent 4 }}
+    {{- include "loki.multiTenantProxyLabels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/helm/loki/templates/multi-tenant-proxy/service.yaml
+++ b/helm/loki/templates/multi-tenant-proxy/service.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.loki.enabled }}
+{{- if .Values.multiTenantAuth.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: loki-multi-tenant-proxy
+  labels:
+    {{- include "loki.multiTenantProxyLabels" . | nindent 4 }}
+spec:
+  ports:
+  - port: 3100
+    protocol: TCP
+    name: http-read
+  - port: 3101
+    protocol: TCP
+    name: http-write
+  - port: 3102
+    protocol: TCP
+    name: http-backend
+  selector:
+    {{- include "loki.multiTenantProxySelectorLabels" . | nindent 4 }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
This PR first splits the MTP file into several smaller ones and also fixes the label to align with upstream components.