### PR TITLE
add read egress access to world in additional CNPs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix read pods by adding another CNP to allow those egress access to world.
+
 ## [0.16.1] - 2024-02-21
 
 ### Added

--- a/helm/loki/templates/additional-ciliumnetworkpolicy.yaml
+++ b/helm/loki/templates/additional-ciliumnetworkpolicy.yaml
@@ -28,6 +28,20 @@ spec:
   - toEntities:
     - world
 ---
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ include "loki.name" . }}-read-egress
+  namespace: {{ .Release.Namespace }}
+spec:
+  endpointSelector:
+    matchLabels:
+      {{- include "loki.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: read
+  egress:
+  - toEntities:
+    - world
+---
 {{- if .Values.ciliumNetworkPolicy.coredns.enabled }}
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy


### PR DESCRIPTION
Loki-read pods were only able to query logs from the local cache. This fix this and allow them to access logs stored in S3