### PR TITLE
fix helm chart when loki disabled and CNPs enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Helm chart generation when loki is disabled and CNPs are enabled
+
 ## [0.16.2] - 2024-02-22
 
 ### Fixed

--- a/helm/loki/templates/additional-ciliumnetworkpolicy.yaml
+++ b/helm/loki/templates/additional-ciliumnetworkpolicy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ciliumNetworkPolicy.enabled }}
+{{- if and .Values.ciliumNetworkPolicy.enabled .Values.loki.enabled }}
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:


### PR DESCRIPTION
When loki is disabled and CNPs are enabled, chart fails:
```
[loki-app]$ cat testcnp-values.yaml 
ciliumNetworkPolicy:
  enabled: true
loki:
  enabled: false
[loki-app]$ helm template helm/loki/ -f testcnp-values.yaml
Error: template: loki/templates/additional-ciliumnetworkpolicy.yaml:10:10: executing "loki/templates/additional-ciliumnetworkpolicy.yaml" at <include "loki.selectorLabels" .>: error calling include: template: no template "loki.selectorLabels" associated with template "gotpl"

Use --debug flag to render out invalid YAML
[loki-app]$ 
```

This PR fixes it.