### PR TITLE
update coredns cnp to allow egress traffic to k8s-dns-node-cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated the coredns cilium networpolicy to allow egress traffic to `k8s-dns-node-cache` pods.
+
 ## [0.19.0] - 2024-04-03
 
 ### Added

--- a/helm/loki/templates/coredns-ciliumnetworkpolicy.yaml
+++ b/helm/loki/templates/coredns-ciliumnetworkpolicy.yaml
@@ -25,4 +25,7 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: coredns
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+        k8s:k8s-app: k8s-dns-node-cache
 {{- end }}


### PR DESCRIPTION
An issue happened on  `gerbil` and `gcapeverde` where the loki-read and loki-write pods were not able to work because they couldn't communicate with the `k8s-dns-node-cache` pods. Adding those to the egress-coredns cnp will solve this.