### PR TITLE
feat(multi-tenant-gateway): Monitor multi-tenant-gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add monitoring for the multi-tenant-gateway (c.f. https://github.com/giantswarm/giantswarm/issues/29941).
+
 ## [0.21.0] - 2024-07-18
 
 ### Changed

--- a/helm/loki/templates/multi-tenant-proxy/servicemonitor.yaml
+++ b/helm/loki/templates/multi-tenant-proxy/servicemonitor.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.loki.enabled }}
+{{- if .Values.multiTenantAuth.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: loki-multi-tenant-proxy
+  labels:
+    {{- include "loki.multiTenantProxyLabels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "loki.multiTenantProxySelectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http-read
+      path: /metrics
+      relabelings:
+        - sourceLabels: [job]
+          action: replace
+          replacement: "{{ $.Release.Namespace }}/grafana-multi-tenant-proxy-read"
+          targetLabel: job
+    - port: http-write
+      path: /metrics
+      relabelings:
+        - sourceLabels: [job]
+          action: replace
+          replacement: "{{ $.Release.Namespace }}/grafana-multi-tenant-proxy-write"
+          targetLabel: job
+    - port: http-backend
+      path: /metrics
+      relabelings:
+        - sourceLabels: [job]
+          action: replace
+          replacement: "{{ $.Release.Namespace }}/grafana-multi-tenant-proxy-backend"
+          targetLabel: job
+{{- end }}
+{{- end }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/29941

This PR adds the service monitor to monitor the gateway. It is currently useless because it needs a version of mtp with basic metrics exposed (https://github.com/giantswarm/grafana-multi-tenant-proxy/pull/134) but this will ensure knowledge is shared before I go on holidays