### PR TITLE
add support for canary deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for canary deploymnent
+
 ## [0.24.0] - 2024-09-24
 
 ### Added

--- a/helm/loki/templates/canary/_helpers.tpl
+++ b/helm/loki/templates/canary/_helpers.tpl
@@ -1,0 +1,46 @@
+{{/*
+canary fullname
+*/}}
+{{- define "loki-canary.fullname" -}}
+{{ include "loki.name" . }}-canary
+{{- end }}
+
+{{/*
+canary common labels
+*/}}
+{{- define "loki-canary.labels" -}}
+{{ include "loki.labels" . }}
+app.kubernetes.io/component: canary
+{{- end }}
+
+// Canary config is a bit hacky, we expect the replicaset canary to be supported upstream for a proper solution
+// See PR: https://github.com/grafana/loki/pull/13362
+
+{{/*
+canary selector labels
+*/}}
+{{- define "loki-canary.selectorLabels" -}}
+app.kubernetes.io/component: canary
+app.kubernetes.io/instance: loki
+app.kubernetes.io/name: loki
+{{- end }}
+
+{{/*
+Docker image name for loki-canary
+*/}}
+{{- define "loki-canary.image" -}}
+{{ $.Values.global.image.registry }}/giantswarm/loki-canary:{{ .Chart.AppVersion }}
+{{- end -}}
+
+{{/*
+gateway fullname
+*/}}
+{{- define "loki.gatewayFullname" -}}
+{{ include "loki.fullname" . }}-gateway
+{{- end }}
+
+{{/* Determine the public host for the Loki cluster */}}
+{{- define "loki.host" -}}
+{{- $url := printf "%s.%s.svc.%s.:%s" (include "loki.gatewayFullname" .) .Release.Namespace .Values.global.clusterDomain "80" }}
+{{- printf "%s" $url -}}
+{{- end -}}

--- a/helm/loki/templates/canary/_pod.tpl
+++ b/helm/loki/templates/canary/_pod.tpl
@@ -1,0 +1,90 @@
+{{/*
+Pod template used in Daemonset and Deployment
+*/}}
+{{- define "canary.podTemplate" -}}
+metadata:
+  {{- with $.Values.lokiCanary.annotations }}
+  annotations:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+  labels:
+    {{- include "loki-canary.selectorLabels" $ | nindent 4 }}
+    {{- with $.Values.lokiCanary.podLabels }}
+    {{- toYaml . | nindent 8 }}
+    {{- end }}
+spec:
+  serviceAccountName: {{ include "loki-canary.fullname" $ }}
+  {{- with $.Values.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+  securityContext:
+    {{- toYaml $.Values.lokiCanary.podSecurityContext | nindent 4 }}
+  containers:
+    - name: loki-canary
+      image: {{ include "loki-canary.image" $ }}
+      imagePullPolicy: {{ $.Values.lokiCanary.image.pullPolicy }}
+      args:
+        - -addr={{- include "loki.host" $ }}
+        - -labelname={{ $.Values.lokiCanary.labelname }}
+        - -labelvalue=$(POD_NAME)
+        {{- if $.Values.loki.auth_enabled }}
+        - -user={{ $.Values.monitoring.selfMonitoring.tenant.name }}
+        - -tenant-id={{ $.Values.monitoring.selfMonitoring.tenant.name }}
+        - -pass={{ $.Values.monitoring.selfMonitoring.tenant.password }}
+        {{- end }}
+        {{- if $.Values.lokiCanary.push }}
+        - -push=true
+        {{- end }}
+        {{- with $.Values.lokiCanary.extraArgs }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      securityContext:
+        {{- toYaml $.Values.lokiCanary.containerSecurityContext | nindent 8 }}
+      volumeMounts:
+        {{- with $.Values.lokiCanary.extraVolumeMounts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      ports:
+        - name: http-metrics
+          containerPort: 3500
+          protocol: TCP
+      env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        {{- with $.Values.lokiCanary.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with $.Values.lokiCanary.extraEnvFrom }}
+      envFrom:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      readinessProbe:
+        httpGet:
+          path: /metrics
+          port: http-metrics
+        initialDelaySeconds: 15
+        timeoutSeconds: 1
+      {{- with $.Values.lokiCanary.resources}}
+      resources:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- with $.Values.lokiCanary.dnsConfig }}
+  dnsConfig:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $.Values.lokiCanary.nodeSelector }}
+  nodeSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $.Values.lokiCanary.tolerations }}
+  tolerations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  volumes:
+  {{- with $.Values.lokiCanary.extraVolumes }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/loki/templates/canary/daemonset.yaml
+++ b/helm/loki/templates/canary/daemonset.yaml
@@ -1,0 +1,22 @@
+{{- with .Values.lokiCanary -}}
+{{- if and .enabled (eq .mode "daemonset") -}}
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "loki-canary.fullname" $ }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "loki-canary.labels" $ | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "loki-canary.selectorLabels" $ | nindent 6 }}
+  {{- with .updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  template:
+    {{- include "canary.podTemplate" $ | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/helm/loki/templates/canary/deployment.yaml
+++ b/helm/loki/templates/canary/deployment.yaml
@@ -1,0 +1,23 @@
+{{- with .Values.lokiCanary -}}
+{{- if and .enabled (eq .mode "deployment") -}}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "loki-canary.fullname" $ }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "loki-canary.labels" $ | nindent 4 }}
+spec:
+  replicas: {{ .deployment.replicaCount  }}
+  selector:
+    matchLabels:
+      {{- include "loki-canary.selectorLabels" $ | nindent 6 }}
+  {{- with .deployment.strategy }}
+  strategy:
+    {{- toYaml . | trim | nindent 4 }}
+  {{- end }}
+  template:
+    {{- include "canary.podTemplate" $ | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/helm/loki/templates/canary/service.yaml
+++ b/helm/loki/templates/canary/service.yaml
@@ -1,0 +1,21 @@
+{{- with .Values.lokiCanary -}}
+{{- if .enabled -}}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "loki-canary.fullname" $ }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "loki-canary.labels" $ | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http-metrics
+      port: 3500
+      targetPort: http-metrics
+      protocol: TCP
+  selector:
+    {{- include "loki-canary.selectorLabels" $ | nindent 4 }}
+{{- end -}}
+{{- end -}}

--- a/helm/loki/templates/canary/serviceaccount.yaml
+++ b/helm/loki/templates/canary/serviceaccount.yaml
@@ -1,0 +1,21 @@
+{{- with .Values.lokiCanary -}}
+{{- if .enabled -}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "loki-canary.fullname" $ }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "loki-canary.labels" $ | nindent 4 }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ $.Values.loki.serviceAccount.automountServiceAccountToken }}
+{{- with $.Values.loki.serviceAccount.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm/loki/values.yaml
+++ b/helm/loki/values.yaml
@@ -333,3 +333,80 @@ loki:
 
   test:
     enabled: false
+
+# The Loki canary pushes logs to and queries from this loki installation to test
+# that it's working correctly
+lokiCanary:
+  enabled: false
+  mode: deployment
+  # -- Used when `mode=deployment`
+  deployment:
+    replicaCount: 3
+    strategy:
+      type: RollingUpdate
+  # -- If true, the canary will send directly to Loki via the address configured for verification --
+  # -- If false, it will write to stdout and an Agent will be needed to scrape and send the logs --
+  push: true
+  # -- The name of the label to look for at loki when doing the checks.
+  labelname: pod
+  # -- Additional annotations for the `loki-canary` Daemonset
+  annotations: {}
+  # -- Additional labels for each `loki-canary` pod
+  podLabels: {}
+  service:
+    # -- Annotations for loki-canary Service
+    annotations: {}
+    # -- Additional labels for loki-canary Service
+    labels: {}
+  # -- Additional CLI arguments for the `loki-canary' command
+  extraArgs: []
+  # -- Environment variables to add to the canary pods
+  extraEnv: []
+  # -- Environment variables from secrets or configmaps to add to the canary pods
+  extraEnvFrom: []
+  # -- Volume mounts to add to the canary pods
+  extraVolumeMounts: []
+  # -- Volumes to add to the canary pods
+  extraVolumes: []
+  # -- Resource requests and limits for the canary
+  resources: {}
+  # -- DNS config for canary pods
+  dnsConfig: {}
+  # -- Node selector for canary pods
+  nodeSelector: {}
+  # -- Tolerations for canary pods
+  tolerations: []
+  # -- The name of the PriorityClass for loki-canary pods
+  priorityClassName: null
+  # -- Image to use for loki canary
+  image:
+    # -- The Docker registry
+    registry: docker.io
+    # -- Docker image repository
+    repository: grafana/loki-canary
+    # -- Overrides the image tag whose default is the chart's appVersion
+    tag: null
+    # -- Overrides the image tag with an image digest
+    digest: null
+    # -- Docker image pull policy
+    pullPolicy: IfNotPresent
+  # -- The SecurityContext for Loki pods
+  podSecurityContext:
+    fsGroup: 10001
+    runAsGroup: 10001
+    runAsNonRoot: true
+    runAsUser: 10001
+    seccompProfile:
+      type: RuntimeDefault
+  # -- The SecurityContext for Loki containers
+  containerSecurityContext:
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+    allowPrivilegeEscalation: false
+  # -- Update strategy for the `loki-canary` Daemonset pods
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/28584

As upstream PR for deploying canary as a deployment (https://github.com/grafana/loki/pull/13362) is not moving forward, let's implement it in our chart.