### PR TITLE
fix disabling loki

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
 - Upgraded upstream chart from 6.27.0 to 6.28.0 - see [changelog](https://github.com/grafana/loki/blob/main/production/helm/loki/CHANGELOG.md) for more information.
+
+### Fixed
+
+- ensured `.loki.enabled: false` prevents creating any resource
 
 ## [0.28.0] - 2025-02-24
 

--- a/helm/loki/templates/acme-challenge-ciliumnetworkpolicy.yaml
+++ b/helm/loki/templates/acme-challenge-ciliumnetworkpolicy.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.loki.enabled }}
 {{- if and .Values.loki.networkPolicy.enabled (eq .Values.loki.networkPolicy.flavor "cilium") }}
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
@@ -15,4 +16,5 @@ spec:
     - ports:
       - port: "8089"
         protocol: TCP
+{{- end }}
 {{- end }}

--- a/helm/loki/templates/canary/daemonset.yaml
+++ b/helm/loki/templates/canary/daemonset.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.loki.enabled }}
 {{- with .Values.lokiCanary -}}
 {{- if and .enabled (eq .mode "daemonset") -}}
 ---
@@ -18,5 +19,6 @@ spec:
   {{- end }}
   template:
     {{- include "canary.podTemplate" $ | nindent 4 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/helm/loki/templates/canary/deployment.yaml
+++ b/helm/loki/templates/canary/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.loki.enabled }}
 {{- with .Values.lokiCanary -}}
 {{- if and .enabled (eq .mode "deployment") -}}
 ---
@@ -19,5 +20,6 @@ spec:
   {{- end }}
   template:
     {{- include "canary.podTemplate" $ | nindent 4 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/helm/loki/templates/canary/service.yaml
+++ b/helm/loki/templates/canary/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.loki.enabled }}
 {{- with .Values.lokiCanary -}}
 {{- if .enabled -}}
 ---
@@ -17,5 +18,6 @@ spec:
       protocol: TCP
   selector:
     {{- include "loki-canary.selectorLabels" $ | nindent 4 }}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/helm/loki/templates/canary/serviceaccount.yaml
+++ b/helm/loki/templates/canary/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.loki.enabled }}
 {{- with .Values.lokiCanary -}}
 {{- if .enabled -}}
 ---
@@ -16,6 +17,7 @@ automountServiceAccountToken: {{ $.Values.loki.serviceAccount.automountServiceAc
 {{- with $.Values.loki.serviceAccount.imagePullSecrets }}
 imagePullSecrets:
   {{- toYaml . | nindent 2 }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/helm/loki/templates/coredns-ciliumnetworkpolicy.yaml
+++ b/helm/loki/templates/coredns-ciliumnetworkpolicy.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.loki.enabled }}
 {{- if .Values.ciliumNetworkPolicy.coredns.enabled }}
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
@@ -28,4 +29,5 @@ spec:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: kube-system
         k8s:k8s-app: k8s-dns-node-cache
+{{- end }}
 {{- end }}


### PR DESCRIPTION
### What this PR does / why we need it

We have a feature that allows to not install any loki component even though the app is installed.
This PR fixes components that did not know about this flag, and were still trying to create.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
