### PR TITLE
disable keda for the read path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Disable `ScaledObject` resources and enable back hpa for read and gateway components.
+
 ## [0.29.0] - 2025-07-09
 
 ### Added

--- a/helm/loki/values.schema.json
+++ b/helm/loki/values.schema.json
@@ -108,6 +108,15 @@
                             "properties": {
                                 "enabled": {
                                     "type": "boolean"
+                                },
+                                "minReplicas": {
+                                    "type": "integer"
+                                },
+                                "targetCPUUtilizationPercentage": {
+                                    "type": "integer"
+                                },
+                                "targetMemoryUtilizationPercentage": {
+                                    "type": "integer"
                                 }
                             }
                         },
@@ -552,6 +561,15 @@
                             "properties": {
                                 "enabled": {
                                     "type": "boolean"
+                                },
+                                "minReplicas": {
+                                    "type": "integer"
+                                },
+                                "targetCPUUtilizationPercentage": {
+                                    "type": "integer"
+                                },
+                                "targetMemoryUtilizationPercentage": {
+                                    "type": "integer"
                                 }
                             }
                         },

--- a/helm/loki/values.yaml
+++ b/helm/loki/values.yaml
@@ -179,9 +179,12 @@ loki:
       #customWriteUrl: http://loki-multi-tenant-proxy.default.svc.cluster.local:3101
       #customBackendUrl: http://loki-multi-tenant-proxy.default.svc.cluster.local:3102
     autoscaling:
-      enabled: false
-    kedaScaling:
       enabled: true
+      minReplicas: 2
+      targetCPUUtilizationPercentage: 90
+      targetMemoryUtilizationPercentage: 90
+    kedaScaling:
+      enabled: false
       horizontalPodAutoscalerConfig: {}
       pollingInterval: 30
       cooldownPeriod: 300
@@ -235,9 +238,12 @@ loki:
 
   read:
     autoscaling:
-      enabled: false
-    kedaScaling:
       enabled: true
+      minReplicas: 2
+      targetCPUUtilizationPercentage: 90
+      targetMemoryUtilizationPercentage: 90
+    kedaScaling:
+      enabled: false
       horizontalPodAutoscalerConfig: {}
       pollingInterval: 30
       cooldownPeriod: 300


### PR DESCRIPTION
### What this PR does / why we need it

I assumed that Keda was deployed everywhere but as it's not the case, every installation is paging as the loki can't deploy its scaledObjects resources. 

So let's disable those until keda is deployed.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
