### PR TITLE
fix keda cpu and memory triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix keda cpu and memory triggers by making value a string instead of an int.
+
 ## [0.30.0] - 2025-07-28
 
 ### Changed

--- a/helm/loki/values.schema.json
+++ b/helm/loki/values.schema.json
@@ -284,7 +284,7 @@
                                                 "type": "object",
                                                 "properties": {
                                                     "value": {
-                                                        "type": "integer"
+                                                        "type": "string"
                                                     }
                                                 }
                                             },
@@ -625,7 +625,7 @@
                                                 "type": "object",
                                                 "properties": {
                                                     "value": {
-                                                        "type": "integer"
+                                                        "type": "string"
                                                     }
                                                 }
                                             },

--- a/helm/loki/values.yaml
+++ b/helm/loki/values.yaml
@@ -195,12 +195,12 @@ loki:
         metricType: Utilization
         metadata:
            # equivalent of targetMemoryUtilizationPercentage in HPA
-          value: 90
+          value: "90"
       - type: cpu
         metricType: Utilization
         metadata:
           # equivalent of targetCPUUtilizationPercentage in HPA
-          value: 90
+          value: "90"
     deploymentStrategy:
       type: RollingUpdate
       rollingUpdate:
@@ -263,12 +263,12 @@ loki:
         metricType: Utilization
         metadata:
            # equivalent of targetMemoryUtilizationPercentage in HPA
-          value: 90
+          value: "90"
       - type: cpu
         metricType: Utilization
         metadata:
           # equivalent of targetCPUUtilizationPercentage in HPA
-          value: 90
+          value: "90"
     resources:
       limits:
         memory: 3Gi


### PR DESCRIPTION
### What this PR does / why we need it

Loki app is failing everywhere with this error message:
```
Upgrade "loki" failed: cannot patch "loki-gateway" with kind ScaledObject: ScaledObject.keda.sh "loki-gateway" is invalid: [spec.triggers[0].metadata.value: Invalid value: "integer": spec.triggers[0].metadata.value in body must be of type string: "integer", spec.triggers[1].metadata.value: Invalid value: "integer": spec.triggers[1].metadata.value in body must be of type string: "integer"] && cannot patch "loki-read" with kind ScaledObject: ScaledObject.keda.sh "loki-read" is invalid: [spec.triggers[0].metadata.value: Invalid value: "integer": spec.triggers[0].metadata.value in body must be of type string: "integer", spec.triggers[1].metadata.value: Invalid value: "integer": spec.triggers[1].metadata.value in body must be of type string: "integer"]
```

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
