### PR TITLE
Load k8s-sidecar and go-dnsmasq container images from gsoci.azurecr.io by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Load k8s-sidecar and go-dnsmasq container images from gsoci.azurecr.io by default
+
 ## [0.31.0] - 2025-08-11
 
 ### Added

--- a/helm/loki/README.md
+++ b/helm/loki/README.md
@@ -52,7 +52,7 @@ Helm chart for Grafana Loki in simple, scalable mode
 | loki.gateway.extraContainers[0].args[2] | string | `"--hostsfile=/etc/hosts"` |  |
 | loki.gateway.extraContainers[0].args[3] | string | `"--enable-search"` |  |
 | loki.gateway.extraContainers[0].args[4] | string | `"--verbose"` |  |
-| loki.gateway.extraContainers[0].image | string | `"giantswarm/go-dnsmasq:release-1.0.7"` |  |
+| loki.gateway.extraContainers[0].image | string | `"gsoci.azurecr.io/giantswarm/go-dnsmasq:release-1.0.7"` |  |
 | loki.gateway.extraContainers[0].imagePullPolicy | string | `"IfNotPresent"` |  |
 | loki.gateway.extraContainers[0].name | string | `"dnsmasq"` |  |
 | loki.gateway.extraContainers[0].resources.limits.memory | string | `"100Mi"` |  |
@@ -96,7 +96,7 @@ Helm chart for Grafana Loki in simple, scalable mode
 | loki.serviceAccount.imagePullSecrets | list | `[]` | Image pull secrets for the service account |
 | loki.serviceAccount.labels | object | `{}` | Labels for the service account |
 | loki.serviceAccount.name | string | `"loki"` | The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template |
-| loki.sidecar.image.repository | string | `"giantswarm/k8s-sidecar"` |  |
+| loki.sidecar.image.repository | string | `"gsoci.azurecr.io/giantswarm/k8s-sidecar"` |  |
 | loki.sidecar.resources.limits.cpu | string | `"100m"` |  |
 | loki.sidecar.resources.limits.memory | string | `"100Mi"` |  |
 | loki.sidecar.resources.requests.cpu | string | `"50m"` |  |

--- a/helm/loki/values.yaml
+++ b/helm/loki/values.yaml
@@ -150,7 +150,7 @@ loki:
   gateway:
     extraContainers:
       - name: dnsmasq
-        image: "giantswarm/go-dnsmasq:release-1.0.7"
+        image: "gsoci.azurecr.io/giantswarm/go-dnsmasq:release-1.0.7"
         imagePullPolicy: IfNotPresent
         args:
           - --listen
@@ -347,7 +347,7 @@ loki:
 
   sidecar:
     image:
-      repository: giantswarm/k8s-sidecar
+      repository: gsoci.azurecr.io/giantswarm/k8s-sidecar
     securityContext:
       readOnlyRootFilesystem: true
       capabilities:


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3935


### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
