### PR TITLE
chore(deps): upgrade loki helm chart v9 → v10 (9.5.13 → 10.2.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated Loki Helm chart dependency to use `grafana-community/helm-charts` repository.
-- Upgrade upstream loki helm chart from v6 (6.53.0) to v9 (9.5.13), Loki app version 3.6.5 → 3.7.1.
+- Upgrade upstream loki helm chart from v6 (6.53.0) to v10 (10.2.2), Loki app version 3.6.5 → 3.7.1.
 
 ## [0.42.0] - 2026-03-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated Loki Helm chart dependency to use `grafana-community/helm-charts` repository.
+- Upgrade upstream loki helm chart from v6 (6.53.0) to v7 (7.0.0), bumping Loki app version from 3.6.5 to 3.6.7.
 
 ## [0.42.0] - 2026-03-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated Loki Helm chart dependency to use `grafana-community/helm-charts` repository.
-- Upgrade upstream loki helm chart from v6 (6.53.0) to v7 (7.0.0), bumping Loki app version from 3.6.5 to 3.6.7.
+- Upgrade upstream loki helm chart from v6 (6.53.0) to v8 (8.1.3), Loki app version 3.6.5 → 3.6.7.
 
 ## [0.42.0] - 2026-03-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated Loki Helm chart dependency to use `grafana-community/helm-charts` repository.
-- Upgrade upstream loki helm chart from v6 (6.53.0) to v8 (8.1.3), Loki app version 3.6.5 → 3.6.7.
+- Upgrade upstream loki helm chart from v6 (6.53.0) to v9 (9.5.13), Loki app version 3.6.5 → 3.7.1.
 
 ## [0.42.0] - 2026-03-12
 

--- a/helm/loki/Chart.lock
+++ b/helm/loki/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: loki
   repository: https://grafana-community.github.io/helm-charts
-  version: 9.5.13
-digest: sha256:14c5526d8d5503ad1103892e398227c7c2f4949daecd22146bb9a9562a483277
-generated: "2026-04-09T11:48:52.912916376+02:00"
+  version: 10.2.2
+digest: sha256:0f5182c60929f63840b745fbdb9c58f185badcf5491dfbe5d47ef1d829b5558c
+generated: "2026-04-09T11:56:37.720477699+02:00"

--- a/helm/loki/Chart.lock
+++ b/helm/loki/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: loki
   repository: https://grafana-community.github.io/helm-charts
-  version: 8.1.3
-digest: sha256:fe8536ba61207c74cfc9ea3cc1e27c720456044c96e06319f4c73e566341c2ea
-generated: "2026-04-09T11:40:20.070809334+02:00"
+  version: 9.5.13
+digest: sha256:14c5526d8d5503ad1103892e398227c7c2f4949daecd22146bb9a9562a483277
+generated: "2026-04-09T11:48:52.912916376+02:00"

--- a/helm/loki/Chart.lock
+++ b/helm/loki/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: loki
   repository: https://grafana-community.github.io/helm-charts
-  version: 7.0.0
-digest: sha256:55f7155bacb6e3e6a69cc5b869b4fa58fab456a0984aa5f70e35703cfebdb9db
-generated: "2026-04-09T11:26:15.662731072+02:00"
+  version: 8.1.3
+digest: sha256:fe8536ba61207c74cfc9ea3cc1e27c720456044c96e06319f4c73e566341c2ea
+generated: "2026-04-09T11:40:20.070809334+02:00"

--- a/helm/loki/Chart.lock
+++ b/helm/loki/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: loki
   repository: https://grafana-community.github.io/helm-charts
-  version: 6.53.0
-digest: sha256:6de73c132eef087ccfb07cebea1719d97dee24c7bdb8a4fe02595a6b39753daf
-generated: "2026-04-04T14:40:40.313132315+02:00"
+  version: 7.0.0
+digest: sha256:55f7155bacb6e3e6a69cc5b869b4fa58fab456a0984aa5f70e35703cfebdb9db
+generated: "2026-04-09T11:26:15.662731072+02:00"

--- a/helm/loki/Chart.yaml
+++ b/helm/loki/Chart.yaml
@@ -11,7 +11,7 @@ sources:
 icon: https://s.giantswarm.io/app-icons/loki-stack/1/dark.svg
 dependencies:
   - name: loki
-    version: 9.5.13
+    version: 10.2.2
     repository: https://grafana-community.github.io/helm-charts
     condition: loki.enabled
 maintainers:

--- a/helm/loki/Chart.yaml
+++ b/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
-appVersion: 3.6.5
+appVersion: 3.6.7
 version: 0.42.0
 home: https://github.com/giantswarm/loki-app
 sources:
@@ -11,7 +11,7 @@ sources:
 icon: https://s.giantswarm.io/app-icons/loki-stack/1/dark.svg
 dependencies:
   - name: loki
-    version: 6.53.0
+    version: 7.0.0
     repository: https://grafana-community.github.io/helm-charts
     condition: loki.enabled
 maintainers:

--- a/helm/loki/Chart.yaml
+++ b/helm/loki/Chart.yaml
@@ -11,7 +11,7 @@ sources:
 icon: https://s.giantswarm.io/app-icons/loki-stack/1/dark.svg
 dependencies:
   - name: loki
-    version: 7.0.0
+    version: 8.1.3
     repository: https://grafana-community.github.io/helm-charts
     condition: loki.enabled
 maintainers:

--- a/helm/loki/Chart.yaml
+++ b/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: loki
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
-appVersion: 3.6.7
+appVersion: 3.7.1
 version: 0.42.0
 home: https://github.com/giantswarm/loki-app
 sources:
@@ -11,7 +11,7 @@ sources:
 icon: https://s.giantswarm.io/app-icons/loki-stack/1/dark.svg
 dependencies:
   - name: loki
-    version: 8.1.3
+    version: 9.5.13
     repository: https://grafana-community.github.io/helm-charts
     condition: loki.enabled
 maintainers:

--- a/helm/loki/values.yaml
+++ b/helm/loki/values.yaml
@@ -88,6 +88,11 @@ loki:
           requests:
             cpu: 10m
             memory: 10Mi
+    # -- Gateway access log exporter (introduced in v9). Disabled by default
+    # as the image (ghcr.io/jkroepke/access-log-exporter) is not mirrored
+    # in gsoci.azurecr.io. Enable and configure a mirrored image to use it.
+    metrics:
+      enabled: false
     nginxConfig:
       resolver: "127.0.0.1:8053 valid=60s"
     autoscaling:


### PR DESCRIPTION
## Summary

Upgrades the upstream [grafana-community/loki](https://github.com/grafana/loki/tree/main/production/helm/loki) helm chart from **v9 (9.5.13)** to **v10 (10.2.2)**.

| | Before | After |
|---|---|---|
| Upstream chart | 9.5.13 | 10.2.2 |
| Loki app version | 3.7.1 | 3.7.1 |

This is step **4 of 5** in the major version upgrade path to v11.
Depends on: #495

## Functional changes in rendered templates

- **`kubectl.kubernetes.io/default-container` annotation** added to pod specs for read, write, and backend (improves `kubectl exec/logs` UX)
- **seccompProfile: RuntimeDefault** added to memcached (chunks-cache and results-cache) pod and container security contexts
- **runAsNonRoot: true** added to memcached container security contexts
- No new or removed resource types

<details>
<summary>Full helm template diff (version labels excluded)</summary>

```diff
--- /tmp/loki-v9.yaml	2026-04-09 11:49:23.214066914 +0200
+++ /tmp/loki-v10.yaml	2026-04-09 11:57:04.157627710 +0200
@@ -12,7 +12,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: backend
 spec:
   maxUnavailable: 1
@@ -35,7 +35,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: read
 spec:
   maxUnavailable: 1
@@ -58,7 +58,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: write
 spec:
   maxUnavailable: 1
@@ -81,7 +81,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
 automountServiceAccountToken: true
 ---
 # Source: loki/charts/loki/templates/config.yaml
@@ -97,7 +97,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
 data:
   config.yaml: |
     
@@ -226,7 +226,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: gateway
 data:
   nginx.conf: |
@@ -647,7 +647,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
 data:
   runtime-config.yaml: |
     {}
@@ -663,7 +663,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
   name: loki-clusterrole
 rules:
 - apiGroups: [""] # "" indicates the core API group
@@ -682,7 +682,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
 subjects:
   - kind: ServiceAccount
     name: loki
@@ -735,7 +735,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: "backend"
   annotations:
 spec:
@@ -774,7 +774,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: "backend"
     prometheus.io/service-monitor: "false"
     variant: headless
@@ -814,7 +814,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: "memcached-chunks-cache"
   annotations:
     {}
@@ -848,7 +848,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: gateway
   annotations:
 spec:
@@ -876,7 +876,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: gateway
     prometheus.io/service-monitor: "false"
   annotations:
@@ -905,7 +905,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: "read"
   annotations:
 spec:
@@ -944,7 +944,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: "read"
     prometheus.io/service-monitor: "false"
     variant: headless
@@ -984,7 +984,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: "memcached-results-cache"
   annotations:
     {}
@@ -1018,7 +1018,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
   annotations:
 spec:
   type: ClusterIP
@@ -1046,7 +1046,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: "write"
   annotations:
 spec:
@@ -1085,7 +1085,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: "write"
     prometheus.io/service-monitor: "false"
     variant: headless
@@ -1126,7 +1126,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: gateway
 spec:
   strategy:
@@ -1298,7 +1298,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: read
 spec:
   strategy:
@@ -1316,6 +1316,7 @@
     metadata:
       annotations:
         checksum/config: 06113393a898e912f2d12e0801f2a3e1c5707bec50af70df8e027cd52116b399
+        kubectl.kubernetes.io/default-container: "read"
       labels:
         app.kubernetes.io/name: loki
         app.kubernetes.io/instance: loki
@@ -1323,7 +1324,7 @@
         application.giantswarm.io/team: "atlas"
         giantswarm.io/service-type: "managed"
         app.kubernetes.io/component: read
         app.kubernetes.io/part-of: memberlist
     spec:
@@ -1430,7 +1431,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: backend
 spec:
   scaleTargetRef:
@@ -1466,7 +1467,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: gateway
 spec:
   scaleTargetRef:
@@ -1502,7 +1503,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: read
 spec:
   scaleTargetRef:
@@ -1538,7 +1539,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: write
 spec:
   scaleTargetRef:
@@ -1586,7 +1587,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: backend
     app.kubernetes.io/part-of: memberlist
 spec:
@@ -1610,6 +1611,7 @@
     metadata:
       annotations:
         checksum/config: 06113393a898e912f2d12e0801f2a3e1c5707bec50af70df8e027cd52116b399
+        kubectl.kubernetes.io/default-container: "backend"
       labels:
         app.kubernetes.io/name: loki
         app.kubernetes.io/instance: loki
@@ -1617,7 +1619,7 @@
         application.giantswarm.io/team: "atlas"
         giantswarm.io/service-type: "managed"
         app.kubernetes.io/component: backend
         app.kubernetes.io/part-of: memberlist
     spec:
@@ -1779,7 +1781,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: "memcached-chunks-cache"
     name: "memcached-chunks-cache"
   annotations:
@@ -1812,6 +1814,8 @@
         runAsGroup: 11211
         runAsNonRoot: true
         runAsUser: 11211
+        seccompProfile:
+          type: RuntimeDefault
       initContainers:
         []
       nodeSelector:
@@ -1851,6 +1855,9 @@
               drop:
               - ALL
             readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           readinessProbe:
             failureThreshold: 6
             initialDelaySeconds: 5
@@ -1883,6 +1890,9 @@
               drop:
               - ALL
             readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           readinessProbe:
             failureThreshold: 3
             httpGet:
@@ -1912,7 +1922,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: "memcached-results-cache"
     name: "memcached-results-cache"
   annotations:
@@ -1945,6 +1955,8 @@
         runAsGroup: 11211
         runAsNonRoot: true
         runAsUser: 11211
+        seccompProfile:
+          type: RuntimeDefault
       initContainers:
         []
       nodeSelector:
@@ -1984,6 +1996,9 @@
               drop:
               - ALL
             readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           readinessProbe:
             failureThreshold: 6
             initialDelaySeconds: 5
@@ -2016,6 +2031,9 @@
               drop:
               - ALL
             readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           readinessProbe:
             failureThreshold: 3
             httpGet:
@@ -2046,7 +2064,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: write
     app.kubernetes.io/part-of: memberlist
 spec:
@@ -2066,6 +2084,7 @@
     metadata:
       annotations:
         checksum/config: 06113393a898e912f2d12e0801f2a3e1c5707bec50af70df8e027cd52116b399
+        kubectl.kubernetes.io/default-container: "write"
       labels:
         app.kubernetes.io/name: loki
         app.kubernetes.io/instance: loki
@@ -2073,7 +2092,7 @@
         application.giantswarm.io/team: "atlas"
         giantswarm.io/service-type: "managed"
         app.kubernetes.io/component: write
         app.kubernetes.io/part-of: memberlist
     spec:
@@ -2189,7 +2208,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
 spec:
   endpointSelector: {}
   egress:
@@ -2212,7 +2231,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
 spec:
   endpointSelector:
     matchLabels:
@@ -2241,7 +2260,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
 spec:
   endpointSelector:
     matchExpressions:
@@ -2271,7 +2290,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
 spec:
   endpointSelector:
     matchLabels:
@@ -2296,7 +2315,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
 spec:
   endpointSelector:
     matchLabels:
```

</details>