### PR TITLE
chore(deps): upgrade loki helm chart v10 → v11 (10.2.2 → 11.4.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated Loki Helm chart dependency to use `grafana-community/helm-charts` repository.
-- Upgrade upstream loki helm chart from v6 (6.53.0) to v10 (10.2.2), Loki app version 3.6.5 → 3.7.1.
+- Upgrade upstream loki helm chart from v6 (6.53.0) to v11 (11.4.2), Loki app version 3.6.5 → 3.7.1.
 
 ## [0.42.0] - 2026-03-12
 

--- a/helm/loki/Chart.lock
+++ b/helm/loki/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: loki
   repository: https://grafana-community.github.io/helm-charts
-  version: 10.2.2
-digest: sha256:0f5182c60929f63840b745fbdb9c58f185badcf5491dfbe5d47ef1d829b5558c
-generated: "2026-04-09T11:56:37.720477699+02:00"
+  version: 11.4.2
+digest: sha256:df1e7fc3063cb6b5fbaca4f24be2870f55f3982f7a94ef5c968107743f8a8f30
+generated: "2026-04-09T14:54:11.076378782+02:00"

--- a/helm/loki/Chart.yaml
+++ b/helm/loki/Chart.yaml
@@ -11,7 +11,7 @@ sources:
 icon: https://s.giantswarm.io/app-icons/loki-stack/1/dark.svg
 dependencies:
   - name: loki
-    version: 10.2.2
+    version: 11.4.2
     repository: https://grafana-community.github.io/helm-charts
     condition: loki.enabled
 maintainers:


### PR DESCRIPTION
## Summary

Upgrades the upstream grafana-community/loki helm chart from **v10 (10.2.2)** to **v11 (11.4.2)**.

| | Before | After |
|---|---|---|
| Upstream chart | 10.2.2 | 11.4.2 |
| Loki app version | 3.7.1 | 3.7.1 |

## Functional changes

- **Dedicated ServiceAccounts** for gateway, memcached, and write (previously all shared `loki` SA)
- **nginx**: direct `proxy_pass http://...` replaced with variable-based `set $backend ...; proxy_pass $backend$request_uri`
- **k8s-sidecar** 2.5.4 → 2.6.0, **memcached-exporter** v0.15.5 → v0.16.0
- `automountServiceAccountToken: false` on new component ServiceAccounts

<details>
<summary>Full helm template diff (version labels excluded)</summary>

```diff
--- /tmp/loki-v10.yaml	2026-04-09 11:57:04.157627710 +0200
+++ /tmp/loki-v11-final.yaml	2026-04-09 14:54:45.018953366 +0200
@@ -12,7 +12,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: backend
 spec:
   maxUnavailable: 1
@@ -35,7 +35,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: read
 spec:
   maxUnavailable: 1
@@ -58,7 +58,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: write
 spec:
   maxUnavailable: 1
@@ -68,6 +68,40 @@
       app.kubernetes.io/instance: loki
       app.kubernetes.io/component: write
 ---
+# Source: loki/charts/loki/templates/gateway/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: loki-gateway
+  namespace: default
+  labels:
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/managed-by: Helm
+    application.giantswarm.io/team: "atlas"
+    giantswarm.io/service-type: "managed"
+    app.kubernetes.io/component: gateway
+automountServiceAccountToken: false
+---
+# Source: loki/charts/loki/templates/memcached/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: loki-memcached
+  namespace: default
+  labels:
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/managed-by: Helm
+    application.giantswarm.io/team: "atlas"
+    giantswarm.io/service-type: "managed"
+    app.kubernetes.io/component: memcached
+automountServiceAccountToken: false
+---
 # Source: loki/charts/loki/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -81,7 +115,24 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
+automountServiceAccountToken: true
+---
+# Source: loki/charts/loki/templates/write/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: loki-write
+  namespace: default
+  labels:
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/managed-by: Helm
+    application.giantswarm.io/team: "atlas"
+    giantswarm.io/service-type: "managed"
+    app.kubernetes.io/component: write
 automountServiceAccountToken: true
 ---
 # Source: loki/charts/loki/templates/config.yaml
@@ -97,7 +148,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
 data:
   config.yaml: |
     
@@ -226,7 +277,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: gateway
 data:
   nginx.conf: |
@@ -258,17 +309,6 @@
       log_format   main '$remote_addr - $remote_user [$time_local]  $status '
             '"$request" $body_bytes_sent "$http_referer" '
             '"$http_user_agent" "$http_x_forwarded_for"';
-      # Exclude specific requests from logging
-      map $request_uri $track {
-        default 1;
-        ~^/$ 0;
-        ~^/health 0;
-        ~^/metrics 0;
-      }
-    
-      # simple_upstream preset
-      log_format access_log_exporter '$http_host\t$request_method\t$status\t$request_completion\t$request_time\t$request_length\t$bytes_sent\t$upstream_addr\t$upstream_connect_time\t$upstream_header_time\t$upstream_response_time\t$request_uri';
-      access_log syslog:server=127.0.0.1:8514,nohostname access_log_exporter if=$track;
       access_log   /dev/stderr  main;
     
       sendfile     on;
@@ -304,35 +344,42 @@
         # Configure backend targets
         location ^~ /ui {
           
-          proxy_pass       http://loki-read.default.svc.cluster.local:3100$request_uri;
+          set $backend     "http://loki-read.default.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
         }
     
         # Distributor
         location = /api/prom/push {
           
-          proxy_pass       http://loki-write.default.svc.cluster.local:3100$request_uri;
+          set $backend     "http://loki-write.default.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
         }
         location = /loki/api/v1/push {
           
-          proxy_pass       http://loki-write.default.svc.cluster.local:3100$request_uri;
+          set $backend     "http://loki-write.default.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
         }
         location = /distributor/ring {
           
-          proxy_pass       http://loki-write.default.svc.cluster.local:3100$request_uri;
+          set $backend     "http://loki-write.default.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
         }
         location = /otlp/v1/logs {
           
-          proxy_pass       http://loki-write.default.svc.cluster.local:3100$request_uri;
+          set $backend     "http://loki-write.default.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
         }
     
         # Ingester
         location = /flush {
           
-          proxy_pass       http://loki-write.default.svc.cluster.local:3100$request_uri;
+          set $backend     "http://loki-write.default.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
         }
         location ^~ /ingester/ {
           
-          proxy_pass       http://loki-write.default.svc.cluster.local:3100$request_uri;
+          set $backend     "http://loki-write.default.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
         }
         location = /ingester {
           
@@ -342,75 +389,90 @@
         # Ring
         location = /ring {
           
-          proxy_pass       http://loki-write.default.svc.cluster.local:3100$request_uri;
+          set $backend     "http://loki-write.default.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
         }
     
         # MemberListKV
         location = /memberlist {
           
-          proxy_pass       http://loki-write.default.svc.cluster.local:3100$request_uri;
+          set $backend     "http://loki-write.default.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
         }
     
         # Ruler
         location = /ruler/ring {
           
-          proxy_pass       http://loki-backend.default.svc.cluster.local:3100$request_uri;
+          set $backend     "http://loki-backend.default.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
         }
         location = /api/prom/rules {
           
-          proxy_pass       http://loki-backend.default.svc.cluster.local:3100$request_uri;
+          set $backend     "http://loki-backend.default.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
         }
         location ^~ /api/prom/rules/ {
           
-          proxy_pass       http://loki-backend.default.svc.cluster.local:3100$request_uri;
+          set $backend     "http://loki-backend.default.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
         }
         location = /loki/api/v1/rules {
           
-          proxy_pass       http://loki-backend.default.svc.cluster.local:3100$request_uri;
+          set $backend     "http://loki-backend.default.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
         }
         location ^~ /loki/api/v1/rules/ {
           
-          proxy_pass       http://loki-backend.default.svc.cluster.local:3100$request_uri;
+          set $backend     "http://loki-backend.default.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
         }
         location = /prometheus/api/v1/alerts {
           
-          proxy_pass       http://loki-backend.default.svc.cluster.local:3100$request_uri;
+          set $backend     "http://loki-backend.default.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
         }
         location = /prometheus/api/v1/rules {
           
-          proxy_pass       http://loki-backend.default.svc.cluster.local:3100$request_uri;
+          set $backend     "http://loki-backend.default.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
         }
     
         # Compactor
         location = /compactor/ring {
           
-          proxy_pass       http://loki-backend.default.svc.cluster.local:3100$request_uri;
+          set $backend     "http://loki-backend.default.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
         }
         location = /loki/api/v1/delete {
           
-          proxy_pass       http://loki-backend.default.svc.cluster.local:3100$request_uri;
+          set $backend     "http://loki-backend.default.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
         }
         location = /loki/api/v1/cache/generation_numbers {
           
-          proxy_pass       http://loki-backend.default.svc.cluster.local:3100$request_uri;
+          set $backend     "http://loki-backend.default.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
         }
     
         # IndexGateway
         location = /indexgateway/ring {
           
-          proxy_pass       http://loki-backend.default.svc.cluster.local:3100$request_uri;
+          set $backend     "http://loki-backend.default.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
         }
     
         # QueryScheduler
         location = /scheduler/ring {
           
-          proxy_pass       http://loki-backend.default.svc.cluster.local:3100$request_uri;
+          set $backend     "http://loki-backend.default.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
         }
     
         # Config
         location = /config {
           
-          proxy_pass       http://loki-write.default.svc.cluster.local:3100$request_uri;
+          set $backend     "http://loki-write.default.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
         }
     
         # QueryFrontend, Querier
@@ -418,17 +480,20 @@
           proxy_set_header Upgrade $http_upgrade;
           proxy_set_header Connection "upgrade";
           
-          proxy_pass       http://loki-read.default.svc.cluster.local:3100$request_uri;
+          set $backend     "http://loki-read.default.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
         }
         location = /loki/api/v1/tail {
           proxy_set_header Upgrade $http_upgrade;
           proxy_set_header Connection "upgrade";
           
-          proxy_pass       http://loki-read.default.svc.cluster.local:3100$request_uri;
+          set $backend     "http://loki-read.default.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
         }
         location ^~ /api/prom/ {
           
-          proxy_pass       http://loki-read.default.svc.cluster.local:3100$request_uri;
+          set $backend     "http://loki-read.default.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
         }
         location = /api/prom {
           
@@ -438,7 +503,8 @@
           # pass custom headers set by Grafana as X-Query-Tags which are logged as key/value pairs in metrics.go log messages
           proxy_set_header X-Query-Tags "${query_tags},user=${http_x_grafana_user},dashboard_id=${http_x_dashboard_uid},dashboard_title=${http_x_dashboard_title},panel_id=${http_x_panel_id},panel_title=${http_x_panel_title},source_rule_uid=${http_x_rule_uid},rule_name=${http_x_rule_name},rule_folder=${http_x_rule_folder},rule_version=${http_x_rule_version},rule_source=${http_x_rule_source},rule_type=${http_x_rule_type}";
           
-          proxy_pass       http://loki-read.default.svc.cluster.local:3100$request_uri;
+          set $backend     "http://loki-read.default.svc.cluster.local:3100";
+          proxy_pass       $backend$request_uri;
         }
         location = /loki/api/v1 {
           
@@ -446,193 +512,6 @@
         }
       }
     }
-  access-log-exporter.yaml: |
-    presets:
-      loki:
-        metrics:
-          - name: "http_requests_total"
-            type: "counter"
-            help: "The total number of client requests."
-            labels:
-              - name: "host"
-                lineIndex: 0
-              - name: "method"
-                lineIndex: 1
-              - name: "status"
-                lineIndex: 2
-              - name: "path"
-                lineIndex: 11
-                replacements:
-                  - regexp: "^$"
-                    replacement: "/"
-                  - regexp: "^(.+)\\?.+"
-                    replacement: "$1"
-
-          - name: "http_requests_completed_total"
-            type: "counter"
-            help: "The total number of completed requests."
-            valueIndex: 3
-            replacements:
-              - string: "OK"
-                replacement: "1"
-            labels:
-              - name: "host"
-                lineIndex: 0
-              - name: "method"
-                lineIndex: 1
-              - name: "status"
-                lineIndex: 2
-              - name: "path"
-                lineIndex: 11
-                replacements:
-                  - regexp: "^$"
-                    replacement: "/"
-                  - regexp: "^(.+)\\?.+"
-                    replacement: "$1"
-
-          - name: "http_request_size_bytes"
-            type: "histogram"
-            buckets: [ 10,1000,100000,1000000,5000000,50000000,200000000 ]
-            help: "The request length (including request line, header, and request body)"
-            valueIndex: 5
-            labels:
-              - name: "host"
-                lineIndex: 0
-              - name: "method"
-                lineIndex: 1
-              - name: "status"
-                lineIndex: 2
-              - name: "path"
-                lineIndex: 11
-                replacements:
-                  - regexp: "^$"
-                    replacement: "/"
-                  - regexp: "^(.+)\\?.+"
-                    replacement: "$1"
-
-          - name: "http_response_size_bytes"
-            type: "histogram"
-            buckets: [ 10,1000,100000,1000000,5000000,50000000,200000000 ]
-            help: "The response length (including request line, header, and request body)"
-            valueIndex: 6
-            labels:
-              - name: "host"
-                lineIndex: 0
-              - name: "method"
-                lineIndex: 1
-              - name: "status"
-                lineIndex: 2
-              - name: "path"
-                lineIndex: 11
-                replacements:
-                  - regexp: "^$"
-                    replacement: "/"
-                  - regexp: "^(.+)\\?.+"
-                    replacement: "$1"
-
-          - name: "http_request_duration_seconds"
-            type: "histogram"
-            buckets: [ .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10 ]
-            help: "The time spent on receiving and response the response to the client"
-            valueIndex: 4
-            math:
-              enabled: true
-              div: 1000
-            labels:
-              - name: "host"
-                lineIndex: 0
-              - name: "method"
-                lineIndex: 1
-              - name: "status"
-                lineIndex: 2
-              - name: "path"
-                lineIndex: 11
-                replacements:
-                  - regexp: "^$"
-                    replacement: "/"
-                  - regexp: "^(.+)\\?.+"
-                    replacement: "$1"
-
-          - name: "http_upstream_connect_duration_seconds"
-            type: "histogram"
-            buckets: [ .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10 ]
-            help: "The time spent on establishing a connection with the upstream server"
-            valueIndex: 8
-            math:
-              enabled: true
-              div: 1000
-            upstream:
-              enabled: true
-              addrLineIndex: 7
-              excludes: []
-            labels:
-              - name: "host"
-                lineIndex: 0
-              - name: "method"
-                lineIndex: 1
-              - name: "status"
-                lineIndex: 2
-              - name: "path"
-                lineIndex: 11
-                replacements:
-                  - regexp: "^$"
-                    replacement: "/"
-                  - regexp: "^(.+)\\?.+"
-                    replacement: "$1"
-
-          - name: "http_upstream_header_duration_seconds"
-            type: "histogram"
-            help: "The time spent on receiving the response header from the upstream server"
-            buckets: [ .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10 ]
-            valueIndex: 9
-            math:
-              enabled: true
-              div: 1000
-            upstream:
-              enabled: true
-              addrLineIndex: 7
-              excludes: []
-            labels:
-              - name: "host"
-                lineIndex: 0
-              - name: "method"
-                lineIndex: 1
-              - name: "status"
-                lineIndex: 2
-              - name: "path"
-                lineIndex: 11
-                replacements:
-                  - regexp: "^$"
-                    replacement: "/"
-                  - regexp: "^(.+)\\?.+"
-                    replacement: "$1"
-
-          - name: "http_upstream_request_duration_seconds"
-            type: "histogram"
-            help: "The time spent on receiving the response from the upstream server"
-            buckets: [ .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10 ]
-            valueIndex: 10
-            math:
-              enabled: true
-              div: 1000
-            upstream:
-              enabled: true
-              addrLineIndex: 7
-              excludes: []
-            labels:
-              - name: "host"
-                lineIndex: 0
-              - name: "method"
-                lineIndex: 1
-              - name: "status"
-                lineIndex: 2
-              - name: "path"
-                lineIndex: 11
-                replacements:
-                  - regexp: "^$"
-                    replacement: "/"
-                  - regexp: "^(.+)\\?.+"
-                    replacement: "$1"
 ---
 # Source: loki/charts/loki/templates/runtime-configmap.yaml
 apiVersion: v1
@@ -647,7 +526,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
 data:
   runtime-config.yaml: |
     {}
@@ -663,7 +542,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
   name: loki-clusterrole
 rules:
 - apiGroups: [""] # "" indicates the core API group
@@ -682,7 +561,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
 subjects:
   - kind: ServiceAccount
     name: loki
@@ -735,7 +614,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: "backend"
   annotations:
 spec:
@@ -774,7 +653,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: "backend"
     prometheus.io/service-monitor: "false"
     variant: headless
@@ -814,7 +693,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: "memcached-chunks-cache"
   annotations:
     {}
@@ -835,34 +714,6 @@
     app.kubernetes.io/instance: loki
     app.kubernetes.io/component: "memcached-chunks-cache"
 ---
-# Source: loki/charts/loki/templates/gateway/service-gateway-exporter.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: loki-gateway-exporter
-  namespace: default
-  labels:
-    app.kubernetes.io/name: loki
-    app.kubernetes.io/instance: loki
-    app.kubernetes.io/managed-by: Helm
-    application.giantswarm.io/team: "atlas"
-    giantswarm.io/service-type: "managed"
-    app.kubernetes.io/component: gateway
-  annotations:
-spec:
-  type: ClusterIP
-  ports:
-    - name: http-metrics
-      port: 4040
-      targetPort: http-metrics
-      protocol: TCP
-  selector:
-    app.kubernetes.io/name: loki
-    app.kubernetes.io/instance: loki
-    app.kubernetes.io/component: gateway
----
 # Source: loki/charts/loki/templates/gateway/service.yaml
 apiVersion: v1
 kind: Service
@@ -876,7 +727,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: gateway
     prometheus.io/service-monitor: "false"
   annotations:
@@ -905,7 +756,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: "read"
   annotations:
 spec:
@@ -944,7 +795,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: "read"
     prometheus.io/service-monitor: "false"
     variant: headless
@@ -984,7 +835,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: "memcached-results-cache"
   annotations:
     {}
@@ -1018,7 +869,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
   annotations:
 spec:
   type: ClusterIP
@@ -1046,7 +897,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: "write"
   annotations:
 spec:
@@ -1085,7 +936,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: "write"
     prometheus.io/service-monitor: "false"
     variant: headless
@@ -1126,7 +977,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: gateway
 spec:
   strategy:
@@ -1143,13 +994,14 @@
   template:
     metadata:
       annotations:
-        checksum/config: c021ea715989a565293727d451fb5683a81bddfea3517ce1addeaa04053e8e8c
+        checksum/config: eb2a8bde65f0721ee3802b83a9c0fc4405bb47abc358ecc725eacdcbafe815bb
       labels:
         app.kubernetes.io/name: loki
         app.kubernetes.io/instance: loki
         app.kubernetes.io/component: gateway
     spec:
-      serviceAccountName: loki
+      serviceAccountName: loki-gateway
+      automountServiceAccountToken: false
       enableServiceLinks: true
       
       securityContext:
@@ -1195,54 +1047,6 @@
             requests:
               cpu: 50m
               memory: 50Mi
-        - name: exporter
-          image: ghcr.io/jkroepke/access-log-exporter:0.3.8
-          imagePullPolicy: IfNotPresent
-          ports:
-            - containerPort: 4040
-              name: http-metrics
-            - containerPort: 8514
-              name: syslog
-          args:
-            - --nginx.scrape-url
-            - http://127.0.0.1:8080/stub_status
-            - --preset
-            - loki
-          resources:
-            limits: {}
-            requests: {}
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            privileged: false
-            readOnlyRootFilesystem: true
-            runAsGroup: 65532
-            runAsNonRoot: true
-            runAsUser: 65532
-            seccompProfile:
-              type: RuntimeDefault
-          readinessProbe:
-            failureThreshold: 3
-            httpGet:
-              path: /health
-              port: http-metrics
-            initialDelaySeconds: 5
-            periodSeconds: 5
-            timeoutSeconds: 3
-          livenessProbe:
-            failureThreshold: 3
-            httpGet:
-              path: /health
-              port: http-metrics
-            initialDelaySeconds: 30
-            periodSeconds: 10
-            timeoutSeconds: 5
-          volumeMounts:
-            - name: config
-              mountPath: /config.yaml
-              subPath: access-log-exporter.yaml
         - args:
           - --listen
           - 127.0.0.1:8053
@@ -1298,7 +1102,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: read
 spec:
   strategy:
@@ -1324,12 +1128,13 @@
         application.giantswarm.io/team: "atlas"
         giantswarm.io/service-type: "managed"
         app.kubernetes.io/component: read
         app.kubernetes.io/part-of: memberlist
     spec:
       serviceAccountName: loki
       enableServiceLinks: true
+      automountServiceAccountToken: true
       securityContext:
         fsGroup: 10001
         fsGroupChangePolicy: OnRootMismatch
@@ -1349,6 +1154,8 @@
                 app.kubernetes.io/name: 'loki'
             topologyKey: kubernetes.io/hostname
       volumes:
+        - name: temp
+          emptyDir: {}
         - name: config
           configMap:
             name: loki
@@ -1358,8 +1165,6 @@
         - name: runtime-config
           configMap:
             name: loki-runtime
-        - name: temp
-          emptyDir: {}
         - name: data
           emptyDir: {}
       containers:
@@ -1407,10 +1212,10 @@
               mountPath: /etc/loki/config
             - name: runtime-config
               mountPath: /etc/loki/runtime-config
-            - name: temp
-              mountPath: /tmp
             - name: data
               mountPath: /var/loki
+            - name: temp
+              mountPath: /tmp
           resources:
             limits:
               memory: 3Gi
@@ -1431,7 +1236,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: backend
 spec:
   scaleTargetRef:
@@ -1467,7 +1272,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: gateway
 spec:
   scaleTargetRef:
@@ -1503,7 +1308,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: read
 spec:
   scaleTargetRef:
@@ -1539,7 +1344,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: write
 spec:
   scaleTargetRef:
@@ -1587,7 +1392,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: backend
     app.kubernetes.io/part-of: memberlist
 spec:
@@ -1619,7 +1424,7 @@
         application.giantswarm.io/team: "atlas"
         giantswarm.io/service-type: "managed"
         app.kubernetes.io/component: backend
         app.kubernetes.io/part-of: memberlist
     spec:
@@ -1645,6 +1450,8 @@
                 app.kubernetes.io/name: 'loki'
             topologyKey: kubernetes.io/hostname
       volumes:
+        - name: temp
+          emptyDir: {}
         - name: config
           configMap:
             name: loki
@@ -1654,8 +1461,6 @@
         - name: runtime-config
           configMap:
             name: loki-runtime
-        - name: temp
-          emptyDir: {}
         - name: data
         - name: sc-rules-volume
           emptyDir: {}
@@ -1706,10 +1511,10 @@
               mountPath: /etc/loki/config
             - name: runtime-config
               mountPath: /etc/loki/runtime-config
-            - name: temp
-              mountPath: /tmp
             - name: data
               mountPath: /var/loki
+            - name: temp
+              mountPath: /tmp
             - name: sc-rules-volume
               mountPath: "/rules"
           resources:
@@ -1720,7 +1525,7 @@
               memory: 1Gi
         
         - name: loki-sc-rules
-          image: gsoci.azurecr.io/giantswarm/k8s-sidecar:2.5.4
+          image: gsoci.azurecr.io/giantswarm/k8s-sidecar:2.6.0
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -1781,7 +1586,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: "memcached-chunks-cache"
     name: "memcached-chunks-cache"
   annotations:
@@ -1808,7 +1613,7 @@
         name: "memcached-chunks-cache"
       annotations:
     spec:
-      serviceAccountName: loki
+      serviceAccountName: loki-memcached
       securityContext:
         fsGroup: 11211
         runAsGroup: 11211
@@ -1873,7 +1678,7 @@
               port: client
             timeoutSeconds: 5
         - name: exporter
-          image: gsoci.azurecr.io/prom/memcached-exporter:v0.15.5
+          image: gsoci.azurecr.io/prom/memcached-exporter:v0.16.0
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150
@@ -1922,7 +1727,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: "memcached-results-cache"
     name: "memcached-results-cache"
   annotations:
@@ -1949,7 +1754,7 @@
         name: "memcached-results-cache"
       annotations:
     spec:
-      serviceAccountName: loki
+      serviceAccountName: loki-memcached
       securityContext:
         fsGroup: 11211
         runAsGroup: 11211
@@ -2014,7 +1819,7 @@
               port: client
             timeoutSeconds: 5
         - name: exporter
-          image: gsoci.azurecr.io/prom/memcached-exporter:v0.15.5
+          image: gsoci.azurecr.io/prom/memcached-exporter:v0.16.0
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150
@@ -2064,7 +1869,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
     app.kubernetes.io/component: write
     app.kubernetes.io/part-of: memberlist
 spec:
@@ -2092,12 +1897,13 @@
         application.giantswarm.io/team: "atlas"
         giantswarm.io/service-type: "managed"
         app.kubernetes.io/component: write
         app.kubernetes.io/part-of: memberlist
     spec:
-      serviceAccountName: loki
+      serviceAccountName: loki-write
       enableServiceLinks: true
+      automountServiceAccountToken: true
       securityContext:
         fsGroup: 10001
         fsGroupChangePolicy: OnRootMismatch
@@ -2117,6 +1923,8 @@
                 app.kubernetes.io/name: 'loki'
             topologyKey: kubernetes.io/hostname
       volumes:
+        - name: temp
+          emptyDir: {}
         - name: config
           configMap:
             name: loki
@@ -2126,8 +1934,6 @@
         - name: runtime-config
           configMap:
             name: loki-runtime
-        - name: temp
-          emptyDir: {}
         - name: data
       containers:
         - name: write
@@ -2173,10 +1979,10 @@
               mountPath: /etc/loki/config
             - name: runtime-config
               mountPath: /etc/loki/runtime-config
-            - name: temp
-              mountPath: /tmp
             - name: data
               mountPath: /var/loki
+            - name: temp
+              mountPath: /tmp
           resources:
             limits:
               memory: 4Gi
@@ -2208,7 +2014,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
 spec:
   endpointSelector: {}
   egress:
@@ -2231,7 +2037,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
 spec:
   endpointSelector:
     matchLabels:
@@ -2260,7 +2066,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
 spec:
   endpointSelector:
     matchExpressions:
@@ -2290,7 +2096,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
 spec:
   endpointSelector:
     matchLabels:
@@ -2315,7 +2121,7 @@
     application.giantswarm.io/team: "atlas"
     giantswarm.io/service-type: "managed"
 spec:
   endpointSelector:
     matchLabels:
```

</details>