### PR TITLE
disable per-component serviceaccounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Disabled per-component serviceaccounts so we rely on a central serviceaccount that has proper IRSA annotation.
+
 ## [0.43.0] - 2026-04-13
 
 ### Changed

--- a/helm/loki/values.yaml
+++ b/helm/loki/values.yaml
@@ -154,6 +154,10 @@ loki:
             inline: "Bad Request"
 
   backend:
+    # -- Disable per-component service account so backend uses the shared
+    # top-level "loki" service account (required for IRSA annotations to apply).
+    serviceAccount:
+      create: false
     autoscaling:
       enabled: true
       minReplicas: 2
@@ -167,6 +171,10 @@ loki:
         cpu: 200m
 
   read:
+    # -- Disable per-component service account so read uses the shared
+    # top-level "loki" service account (required for IRSA annotations to apply).
+    serviceAccount:
+      create: false
     autoscaling:
       enabled: true
       minReplicas: 2
@@ -182,6 +190,10 @@ loki:
       - -querier.multi-tenant-queries-enabled
 
   write:
+    # -- Disable per-component service account so write uses the shared
+    # top-level "loki" service account (required for IRSA annotations to apply).
+    serviceAccount:
+      create: false
     autoscaling:
       enabled: true
       minReplicas: 2


### PR DESCRIPTION
### What this PR does / why we need it

Latest version (0.43.0) introduced per-component serviceaccounts, but this breaks IRSA.
This change should restore S3 access. 

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
