### PR TITLE
Keep crossplane storage no matter what

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Make sure crossplane cannot delete Crossplane azure storage accounts/containers and s3 buckets.
+
 ## [0.43.1] - 2026-04-14
 
 ### Fixed

--- a/helm/loki/templates/crossplane/aws/bucket.yaml
+++ b/helm/loki/templates/crossplane/aws/bucket.yaml
@@ -17,7 +17,10 @@ spec:
     {{- if .Values.crossplane.observeOnly }}
     - Observe
     {{- else }}
-    - "*"
+    - "Create"
+    - "Delete"
+    - "LateInitialize"
+    - "Observe"
     {{- end }}
   forProvider:
     forceDestroy: false

--- a/helm/loki/templates/crossplane/aws/bucket.yaml
+++ b/helm/loki/templates/crossplane/aws/bucket.yaml
@@ -18,7 +18,7 @@ spec:
     - Observe
     {{- else }}
     - "Create"
-    - "Delete"
+    - "Update"
     - "LateInitialize"
     - "Observe"
     {{- end }}

--- a/helm/loki/templates/crossplane/azure/account.yaml
+++ b/helm/loki/templates/crossplane/azure/account.yaml
@@ -20,7 +20,7 @@ spec:
     - Observe
     {{- else }}
     - "Create"
-    - "Delete"
+    - "Update"
     - "LateInitialize"
     - "Observe"
     {{- end }}

--- a/helm/loki/templates/crossplane/azure/account.yaml
+++ b/helm/loki/templates/crossplane/azure/account.yaml
@@ -19,7 +19,10 @@ spec:
     {{- if .Values.crossplane.observeOnly }}
     - Observe
     {{- else }}
-    - "*"
+    - "Create"
+    - "Delete"
+    - "LateInitialize"
+    - "Observe"
     {{- end }}
   forProvider:
     resourceGroupName: {{ .Values.crossplane.azure.resourceGroup }}

--- a/helm/loki/templates/crossplane/azure/container.yaml
+++ b/helm/loki/templates/crossplane/azure/container.yaml
@@ -17,7 +17,10 @@ spec:
     {{- if .Values.crossplane.observeOnly }}
     - Observe
     {{- else }}
-    - "*"
+    - "Create"
+    - "Delete"
+    - "LateInitialize"
+    - "Observe"
     {{- end }}
   forProvider:
     storageAccountNameSelector:

--- a/helm/loki/templates/crossplane/azure/container.yaml
+++ b/helm/loki/templates/crossplane/azure/container.yaml
@@ -18,7 +18,7 @@ spec:
     - Observe
     {{- else }}
     - "Create"
-    - "Delete"
+    - "Update"
     - "LateInitialize"
     - "Observe"
     {{- end }}


### PR DESCRIPTION
This PR:

We had and incident during the night causing issues with Crossplane resources.
Let's make sure that even if we delete the crossplane resources, object storage is kept