### PR TITLE
fix: fix ABS override_app_version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ workflows:
           app_catalog_test: "giantswarm-test-catalog"
           chart: "loki"
           ct_config: ".circleci/ct-config.yaml"
+          override_app_version: false
           # Trigger job on git tag.
           filters:
             tags:
@@ -27,6 +28,7 @@ workflows:
           chart: "loki"
           ct_config: ".circleci/ct-config.yaml"
           persist_chart_archive: true
+          override_app_version: false
           # Trigger job on git tag.
           filters:
             tags:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Fix ABS config to not override AppVersion in Chart.yaml
+
 ## [0.45.0] - 2026-05-07
 
 ### Changed


### PR DESCRIPTION
### What this PR does / why we need it

In recent versions, ABS and architect orb changed the default behaviour for overriding the AppVersion in Chart.yaml when building and pushing charts. Now the default is to override it.
This does not work for this chart, since we use an upstream image with a different version than the chart itself.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
