### PR TITLE
fix: add egress to kube-apiserver to fix CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add a `kubernetes`-flavor NetworkPolicy granting the backend pods egress to the kube-apiserver (TCP 443/6443) to fix standalone platforms and CI tests.
+
 ## [0.45.0] - 2026-05-07
 
 ### Changed

--- a/helm/loki/templates/backend/backend-kubeapiserver-networkpolicy.yaml
+++ b/helm/loki/templates/backend/backend-kubeapiserver-networkpolicy.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.loki.enabled }}
+{{- if and .Values.loki.networkPolicy.egressKubeApiserver.enabled (eq .Values.loki.networkPolicy.flavor "kubernetes") }}
+---
+# The upstream chart only renders a kube-apiserver egress rule for the "cilium"
+# flavor. The "kubernetes" flavor has no equivalent, so the backend's k8s-sidecar (rules watcher)
+# cannot reach the API server once a CNI enforces NetworkPolicies.
+# This wrapper template fills that gap.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations:
+    ignore-check.kube-linter.io/sorted-keys: "imported lists from upstream chart can't be sorted (`loki.labels` and `loki.backendSelectorLabels`)"
+  labels:
+    {{- include "loki.labels" . | nindent 4 }}
+  name: {{ include "loki.name" . }}-backend-kubeapiserver-egress
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "loki.backendSelectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
+{{- end }}
+{{- end }}


### PR DESCRIPTION
### What this PR does / why we need it

Adds a `kubernetes`-flavor NetworkPolicy granting the backend pods egress to the kube-apiserver (TCP 443/6443).
The upstream chart only renders this rule for the `cilium` flavor, so under the `kubernetes flavor the backend's `k8s-sidecar` (rules watcher) could not reach the API server once the CNI enforce NetworkPolicies, leaving `loki-backend` pods stuck at 1/2 Ready.
This broke the ATS smoke tests after CI moved to a kind image whose kindnet enforces NetworkPolicies.
Production (cilium flavor) was unaffected.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
