### PR TITLE
chore: remove `ct_config` from push-to-app-catalog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,6 @@ workflows:
           app_catalog: "giantswarm-catalog"
           app_catalog_test: "giantswarm-test-catalog"
           chart: "loki"
-          ct_config: ".circleci/ct-config.yaml"
           override_app_version: false
           # Trigger job on git tag.
           filters:
@@ -26,7 +25,6 @@ workflows:
           app_catalog: "control-plane-catalog"
           app_catalog_test: "control-plane-test-catalog"
           chart: "loki"
-          ct_config: ".circleci/ct-config.yaml"
           persist_chart_archive: true
           override_app_version: false
           # Trigger job on git tag.


### PR DESCRIPTION
`ct_config` has been **ignored by architect-orb since v9.0.0 (when the `helm-lint` step it controlled was removed)** — passing it currently does nothing.

It is removed in the upcoming **architect-orb v10.0.0**. Because CircleCI fails config compilation on unknown job arguments, any repo still passing it will break the moment Renovate bumps the orb to v10. Merging this beforehand makes that bump a no-op for you.

No behaviour change: the parameter is already a no-op today.

Part of giantswarm/roadmap#4066