### PR TITLE
feat: add gatewayRoute.requestMirror, disabled by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The ServiceMonitor is no longer gated on the prometheus-operator CRD being present: set `loki.monitoring.serviceMonitor.enabled: false` on clusters without it.
 - The built-in MinIO subchart is deprecated upstream: `loki.minio.enabled` now also needs `loki.ignoreMinioDeprecation: true`, and goes away on 2026-10-31.
 
+### Added
+
+- Add `gatewayRoute.requestMirror`, which mirrors matched requests to a second backend in addition to the primary one. Disabled by default, so rendered output is unchanged unless it is switched on. Mirroring is fire-and-forget: Envoy always ignores the mirror's response, so it cannot slow down or break the primary path, and mirrored requests are never retried. Supports `percent` for ramping onto a busy installation. Applied to `additionalRules` only, since `gatewayRoute.filters` feeds the default rule that rejects requests without an `X-Scope-OrgID` header.
+
 ## [0.46.1] - 2026-08-12
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `gatewayRoute.requestMirror`, an optional `RequestMirror` filter on `gatewayRoute.additionalRules`. Disabled by default.
+- Add `gatewayRoute.requestMirror`, an optional `RequestMirror` filter on `gatewayRoute.additionalRules`, plus the `ReferenceGrant` a cross-namespace `backendRef` needs. Disabled by default.
 
 ## [0.46.1] - 2026-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `gatewayRoute.requestMirror`, which mirrors matched requests to a second backend in addition to the primary one. Disabled by default, so rendered output is unchanged unless it is switched on. Mirroring is fire-and-forget: Envoy always ignores the mirror's response, so it cannot slow down or break the primary path, and mirrored requests are never retried. Supports `percent` for ramping onto a busy installation. Applied to `additionalRules` only, since `gatewayRoute.filters` feeds the default rule that rejects requests without an `X-Scope-OrgID` header.
+- Add `gatewayRoute.requestMirror`, an optional `RequestMirror` filter on `gatewayRoute.additionalRules`. Disabled by default.
 
 ## [0.46.1] - 2026-08-12
 

--- a/helm/loki/templates/route-gateway.yaml
+++ b/helm/loki/templates/route-gateway.yaml
@@ -27,13 +27,14 @@ spec:
     {{- tpl (toYaml .) $root | nindent 4 }}
   {{- end }}
   rules:
-    {{- $mirror := $route.requestMirror | default dict }}
-    {{- range $rule := ($route.additionalRules | default list) }}
+    {{- range $rule := $route.additionalRules }}
+    {{- /* Copy first — `set` would write the filter into .Values. Outside the
+           `if`: an $r declared inside is undefined at `tpl` (parse-time scope). */}}
     {{- $r := deepCopy $rule }}
-    {{- if $mirror.enabled }}
-    {{- /* Not on $route.filters: those feed the default rule, which rejects requests
-           without an X-Scope-OrgID header. deepCopy: $rule is shared values. */}}
-    {{- $requestMirror := dict "backendRef" $mirror.backendRef }}
+    {{- if $route.requestMirror.enabled }}
+    {{- /* Not $route.filters: those feed the default rule, which rejects
+           requests missing X-Scope-OrgID — only rejections would be copied. */}}
+    {{- $requestMirror := dict "backendRef" $route.requestMirror.backendRef }}
     {{- $_ := set $r "filters" (append (default list $r.filters) (dict "type" "RequestMirror" "requestMirror" $requestMirror)) }}
     {{- end }}
     {{- tpl (toYaml (list $r)) $root | nindent 4 }}
@@ -50,8 +51,8 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 
-{{- $mirrorBackend := $mirror.backendRef | default dict }}
-{{- if and $mirror.enabled $mirrorBackend.namespace (ne $mirrorBackend.namespace .Release.Namespace) }}
+{{- $backendRef := $route.requestMirror.backendRef }}
+{{- if and $route.requestMirror.enabled $backendRef.namespace (ne $backendRef.namespace .Release.Namespace) }}
 ---
 # A cross-namespace backendRef is ignored without a grant in the backend's
 # namespace, and the mirror is fire-and-forget, so the only symptom would be
@@ -60,7 +61,7 @@ apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:
   name: {{ include "loki.gatewayFullname" . }}-mirror
-  namespace: {{ $mirrorBackend.namespace }}
+  namespace: {{ $backendRef.namespace }}
   labels:
     {{- include "loki.gatewayLabels" . | nindent 4 }}
 spec:
@@ -71,7 +72,7 @@ spec:
   to:
   - group: ""
     kind: Service
-    name: {{ $mirrorBackend.name }}
+    name: {{ $backendRef.name }}
 {{- end }}
 
 {{- if and $route.securityPolicy $route.securityPolicy.enabled }}

--- a/helm/loki/templates/route-gateway.yaml
+++ b/helm/loki/templates/route-gateway.yaml
@@ -31,16 +31,8 @@ spec:
     {{- range $rule := ($route.additionalRules | default list) }}
     {{- $r := deepCopy $rule }}
     {{- if $mirror.enabled }}
-    {{- /*
-      Mirror requests to a second backend, fire-and-forget: Envoy always ignores the
-      mirror's response, so this cannot affect the primary write path.
-
-      It goes on the additionalRules, not on $route.filters, because those feed the
-      default rule -- the one that rejects requests without an X-Scope-OrgID header.
-      Mirroring there would copy only rejected requests.
-
-      deepCopy first: $rule is shared values, and set would otherwise mutate them.
-    */}}
+    {{- /* Not on $route.filters: those feed the default rule, which rejects requests
+           without an X-Scope-OrgID header. deepCopy: $rule is shared values. */}}
     {{- $requestMirror := dict "backendRef" $mirror.backendRef }}
     {{- $_ := set $r "filters" (append (default list $r.filters) (dict "type" "RequestMirror" "requestMirror" $requestMirror)) }}
     {{- end }}

--- a/helm/loki/templates/route-gateway.yaml
+++ b/helm/loki/templates/route-gateway.yaml
@@ -50,6 +50,30 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 
+{{- $mirrorBackend := $mirror.backendRef | default dict }}
+{{- if and $mirror.enabled $mirrorBackend.namespace (ne $mirrorBackend.namespace .Release.Namespace) }}
+---
+# A cross-namespace backendRef is ignored without a grant in the backend's
+# namespace, and the mirror is fire-and-forget, so the only symptom would be
+# logs that never arrive. v1beta1: v1 needs Gateway API >= v1.5.0.
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: {{ include "loki.gatewayFullname" . }}-mirror
+  namespace: {{ $mirrorBackend.namespace }}
+  labels:
+    {{- include "loki.gatewayLabels" . | nindent 4 }}
+spec:
+  from:
+  - group: gateway.networking.k8s.io
+    kind: {{ $route.kind | default "HTTPRoute" }}
+    namespace: {{ .Release.Namespace }}
+  to:
+  - group: ""
+    kind: Service
+    name: {{ $mirrorBackend.name }}
+{{- end }}
+
 {{- if and $route.securityPolicy $route.securityPolicy.enabled }}
 {{- $policy := $route.securityPolicy }}
 ---

--- a/helm/loki/templates/route-gateway.yaml
+++ b/helm/loki/templates/route-gateway.yaml
@@ -42,9 +42,6 @@ spec:
       deepCopy first: $rule is shared values, and set would otherwise mutate them.
     */}}
     {{- $requestMirror := dict "backendRef" $mirror.backendRef }}
-    {{- with $mirror.percent }}
-    {{- $_ := set $requestMirror "percent" . }}
-    {{- end }}
     {{- $_ := set $r "filters" (append (default list $r.filters) (dict "type" "RequestMirror" "requestMirror" $requestMirror)) }}
     {{- end }}
     {{- tpl (toYaml (list $r)) $root | nindent 4 }}

--- a/helm/loki/templates/route-gateway.yaml
+++ b/helm/loki/templates/route-gateway.yaml
@@ -27,8 +27,27 @@ spec:
     {{- tpl (toYaml .) $root | nindent 4 }}
   {{- end }}
   rules:
-    {{- with $route.additionalRules }}
-    {{- tpl (toYaml .) $root | nindent 4 }}
+    {{- $mirror := $route.requestMirror | default dict }}
+    {{- range $rule := ($route.additionalRules | default list) }}
+    {{- $r := deepCopy $rule }}
+    {{- if $mirror.enabled }}
+    {{- /*
+      Mirror requests to a second backend, fire-and-forget: Envoy always ignores the
+      mirror's response, so this cannot affect the primary write path.
+
+      It goes on the additionalRules, not on $route.filters, because those feed the
+      default rule -- the one that rejects requests without an X-Scope-OrgID header.
+      Mirroring there would copy only rejected requests.
+
+      deepCopy first: $rule is shared values, and set would otherwise mutate them.
+    */}}
+    {{- $requestMirror := dict "backendRef" $mirror.backendRef }}
+    {{- with $mirror.percent }}
+    {{- $_ := set $requestMirror "percent" . }}
+    {{- end }}
+    {{- $_ := set $r "filters" (append (default list $r.filters) (dict "type" "RequestMirror" "requestMirror" $requestMirror)) }}
+    {{- end }}
+    {{- tpl (toYaml (list $r)) $root | nindent 4 }}
     {{- end }}
     - backendRefs:
         - name: {{ include "loki.gatewayFullname" . }}

--- a/helm/loki/values.yaml
+++ b/helm/loki/values.yaml
@@ -264,9 +264,6 @@ gatewayRoute:
   requestMirror:
     # -- Enables or disables mirroring
     enabled: false
-    # -- Percentage of requests to mirror, 0-100. Unset mirrors all of them.
-    # Useful for ramping onto a busy installation.
-    percent: null
     # -- Backend receiving the mirrored requests. A cross-namespace reference also
     # requires a ReferenceGrant in the target namespace, without which the route
     # reports ResolvedRefs=False.

--- a/helm/loki/values.yaml
+++ b/helm/loki/values.yaml
@@ -256,17 +256,13 @@ gatewayRoute:
   # -- Enables or disables the route
   enabled: false
 
-  # -- Mirror matched requests to a second backend, in addition to the primary one.
-  # Fire-and-forget: Envoy always ignores the mirror's response, so this cannot slow
-  # down or break the primary path. It also means mirrored requests are never retried
-  # -- if the mirror backend is unavailable they are dropped silently.
-  # Applied to `additionalRules` only, not to the default rule.
+  # -- Mirror `additionalRules` requests to a second backend, fire-and-forget:
+  # responses are ignored and mirrored requests are never retried.
   requestMirror:
     # -- Enables or disables mirroring
     enabled: false
-    # -- Backend receiving the mirrored requests. A cross-namespace reference also
-    # requires a ReferenceGrant in the target namespace, without which the route
-    # reports ResolvedRefs=False.
+    # -- Backend receiving the mirrored requests. A cross-namespace reference needs a
+    # ReferenceGrant in the target namespace.
     backendRef: {}
     #   name: alloy-logexporter
     #   namespace: monitoring

--- a/helm/loki/values.yaml
+++ b/helm/loki/values.yaml
@@ -261,8 +261,8 @@ gatewayRoute:
   requestMirror:
     # -- Enables or disables mirroring
     enabled: false
-    # -- Backend receiving the mirrored requests. A cross-namespace reference needs a
-    # ReferenceGrant in the target namespace.
+    # -- Backend receiving the mirrored requests. When `namespace` differs from the
+    # release namespace, the chart also creates the ReferenceGrant the reference needs.
     backendRef: {}
     #   name: alloy-logexporter
     #   namespace: monitoring

--- a/helm/loki/values.yaml
+++ b/helm/loki/values.yaml
@@ -256,6 +256,25 @@ gatewayRoute:
   # -- Enables or disables the route
   enabled: false
 
+  # -- Mirror matched requests to a second backend, in addition to the primary one.
+  # Fire-and-forget: Envoy always ignores the mirror's response, so this cannot slow
+  # down or break the primary path. It also means mirrored requests are never retried
+  # -- if the mirror backend is unavailable they are dropped silently.
+  # Applied to `additionalRules` only, not to the default rule.
+  requestMirror:
+    # -- Enables or disables mirroring
+    enabled: false
+    # -- Percentage of requests to mirror, 0-100. Unset mirrors all of them.
+    # Useful for ramping onto a busy installation.
+    percent: null
+    # -- Backend receiving the mirrored requests. A cross-namespace reference also
+    # requires a ReferenceGrant in the target namespace, without which the route
+    # reports ResolvedRefs=False.
+    backendRef: {}
+    #   name: alloy-logexporter
+    #   namespace: monitoring
+    #   port: 3100
+
   # -- Set the route apiVersion, e.g. gateway.networking.k8s.io/v1 or gateway.networking.k8s.io/v1alpha2
   apiVersion: gateway.networking.k8s.io/v1
   # -- Set the route kind

--- a/helm/loki/values.yaml
+++ b/helm/loki/values.yaml
@@ -263,10 +263,10 @@ gatewayRoute:
     enabled: false
     # -- Backend receiving the mirrored requests. When `namespace` differs from the
     # release namespace, the chart also creates the ReferenceGrant the reference needs.
-    backendRef: {}
-    #   name: alloy-logexporter
-    #   namespace: monitoring
-    #   port: 3100
+    backendRef:
+      name: alloy-logexporter
+      namespace: monitoring
+      port: 3100
 
   # -- Set the route apiVersion, e.g. gateway.networking.k8s.io/v1 or gateway.networking.k8s.io/v1alpha2
   apiVersion: gateway.networking.k8s.io/v1


### PR DESCRIPTION
Adds `gatewayRoute.requestMirror`: an optional Envoy `RequestMirror` filter that tees accepted Loki writes to a second backend, for exporting logs out of the platform. Part of [giantswarm/giantswarm#37251](https://github.com/giantswarm/giantswarm/issues/37251). Same value and default as [observability-platform-api#89](https://github.com/giantswarm/observability-platform-api/pull/89), which does the equivalent for the observability API's write route.

Disabled by default, so the plumbing ships everywhere and an installation is enabled by configuration rather than by a PR.

```yaml
gatewayRoute:
  requestMirror:
    enabled: false
    backendRef:
      name: alloy-logexporter
      namespace: monitoring
      port: 3100
```

### Why it merges into `additionalRules`

The mirror has to go on the rules that carry write traffic, which come from `gatewayRoute.additionalRules` — an opaque list of whole rule objects dumped verbatim. `gatewayRoute.filters` feeds the *other* rule, the one that rejects requests without `X-Scope-OrgID`, so a mirror there would copy only rejected requests.

So the template iterates the rules and appends the filter to each, on a `deepCopy`: `set` writes through to `.Values`, and without the copy anything reading `gatewayRoute.additionalRules` later in the same render would see a filter nobody configured. Appending works whether or not a rule already has `filters`.

### The `ReferenceGrant`

A cross-namespace `backendRef` is ignored without a grant in the backend's namespace, so the chart creates one when the mirror is enabled *and* `backendRef.namespace` differs from the release namespace — [a grant is only consulted for references that cross a namespace boundary](https://gateway-api.sigs.k8s.io/concepts/security-model/#2-referencegrant). `v1beta1`, not `v1`: `v1` needs Gateway API v1.5.0, and `gateway-api-bundle` floats on its own semver range.

It previously shipped from `management-cluster-bases` collections, which broke MC creation and is reverted in [management-cluster-bases#696](https://github.com/giantswarm/management-cluster-bases/pull/696). One grant covers observability-platform-api's write route too — `spec.from` is namespace-scoped and both routes live in `loki`.

### Verified

- **Disabled render is byte-identical to `main`** — the change touches the template behind every installation's write path, so this was the acceptance criterion.
- Enabled: the filter lands on every `additionalRules` rule and nowhere else — pre-existing filters are preserved, and the default `X-Scope-OrgID` rule is untouched. A probe reading `.Values.gatewayRoute.additionalRules` after the loop shows no injected filter, so the `deepCopy` holds.
- The grant renders once, in the backend's namespace; a same-namespace `backendRef`, or one with no `namespace` at all, renders no grant and does not error. `helm lint` passes with and without the mirror.
- Live on graveler against real traffic, with the target service in another namespace: route stayed `Accepted`/`ResolvedRefs` True, Envoy built a healthy `httproute/loki/loki-gateway/rule/0-mirror-0` cluster, and 219 audit lines landed in object storage. Reverted afterwards. That run predates the chart-created grant — the grant was applied by hand then, so the template itself is render-verified only.

`percent` is not exposed: any value below 100 yields a silently incomplete archive. Easy to add later if a real need appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)